### PR TITLE
set convo tile height to 80px fixed

### DIFF
--- a/components/ConversationsList.tsx
+++ b/components/ConversationsList.tsx
@@ -35,6 +35,7 @@ const ConversationTile = ({
       <a onClick={onClick}>
         <div
           className={classNames(
+            'h-20',
             'py-2',
             'px-4',
             'md:max-w-sm',


### PR DESCRIPTION
Per designs, conversation tile height should be fixed to 80px, regardless of whether there is a fetched preview message.﻿
