### PR TITLE
Add Message Store

### DIFF
--- a/components/XmtpProvider.tsx
+++ b/components/XmtpProvider.tsx
@@ -1,13 +1,15 @@
 import { useCallback, useEffect, useReducer, useState } from 'react'
+import { Conversation } from '@xmtp/xmtp-js'
 import { Client } from '@xmtp/xmtp-js'
 import { Signer } from 'ethers'
-import { Conversation } from '@xmtp/xmtp-js/dist/types/src/conversations'
 import { XmtpContext, XmtpContextType } from '../contexts/xmtp'
+import useMessageStore from '../hooks/useMessageStore'
 
 export const XmtpProvider: React.FC = ({ children }) => {
   const [wallet, setWallet] = useState<Signer>()
   const [walletAddress, setWalletAddress] = useState<string>()
   const [client, setClient] = useState<Client>()
+  const { getMessages, dispatchMessages } = useMessageStore()
   const [conversations, dispatchConversations] = useReducer(
     (state: Conversation[], newConvos: Conversation[] | undefined) => {
       if (newConvos === undefined) {
@@ -50,6 +52,7 @@ export const XmtpProvider: React.FC = ({ children }) => {
   useEffect(() => {
     const listConversations = async () => {
       if (!client) return
+      console.log('Listing conversations')
       const convos = await client.conversations.list()
       convos.forEach((convo: Conversation) => {
         dispatchConversations([convo])
@@ -74,6 +77,8 @@ export const XmtpProvider: React.FC = ({ children }) => {
     walletAddress,
     client,
     conversations,
+    getMessages,
+    dispatchMessages,
     connect,
     disconnect,
   })
@@ -84,10 +89,21 @@ export const XmtpProvider: React.FC = ({ children }) => {
       walletAddress,
       client,
       conversations,
+      getMessages,
+      dispatchMessages,
       connect,
       disconnect,
     })
-  }, [wallet, walletAddress, client, conversations, connect, disconnect])
+  }, [
+    wallet,
+    walletAddress,
+    client,
+    conversations,
+    getMessages,
+    dispatchMessages,
+    connect,
+    disconnect,
+  ])
 
   return (
     <XmtpContext.Provider value={providerState}>

--- a/contexts/xmtp.ts
+++ b/contexts/xmtp.ts
@@ -1,13 +1,20 @@
-import { createContext } from 'react'
-import { Client } from '@xmtp/xmtp-js'
+import { createContext, Dispatch } from 'react'
+import { Client, Message } from '@xmtp/xmtp-js'
 import { Signer } from 'ethers'
 import { Conversation } from '@xmtp/xmtp-js/dist/types/src/conversations'
+
+export type MessageStoreEvent = {
+  peerAddress: string
+  messages: Message[]
+}
 
 export type XmtpContextType = {
   wallet: Signer | undefined
   walletAddress: string | undefined
   client: Client | undefined
   conversations: Conversation[]
+  getMessages: (peerAddress: string) => Message[]
+  dispatchMessages?: Dispatch<MessageStoreEvent>
   connect: (wallet: Signer) => void
   disconnect: () => void
 }
@@ -17,6 +24,7 @@ export const XmtpContext = createContext<XmtpContextType>({
   walletAddress: undefined,
   client: undefined,
   conversations: [],
+  getMessages: () => [],
   connect: () => undefined,
   disconnect: () => undefined,
 })

--- a/hooks/useConversation.ts
+++ b/hooks/useConversation.ts
@@ -1,13 +1,6 @@
 import { Conversation, Message, Stream } from '@xmtp/xmtp-js'
-import { useContext, useCallback, useState, useReducer, useEffect } from 'react'
+import { useContext, useCallback, useState, useEffect } from 'react'
 import { XmtpContext } from '../contexts/xmtp'
-
-type MessageDeduper = (message: Message) => boolean
-const buildMessageDeduper = (state: Message[]): MessageDeduper => {
-  const existingMessageKeys = state.map((msg) => msg.id)
-
-  return (msg: Message) => existingMessageKeys.indexOf(msg.id) === -1
-}
 
 type OnMessageCallback = () => void
 
@@ -15,7 +8,7 @@ const useConversation = (
   peerAddress: string,
   onMessageCallback?: OnMessageCallback
 ) => {
-  const { client } = useContext(XmtpContext)
+  const { client, getMessages, dispatchMessages } = useContext(XmtpContext)
   const [conversation, setConversation] = useState<Conversation | null>(null)
   const [stream, setStream] = useState<Stream<Message>>()
   useEffect(() => {
@@ -28,18 +21,7 @@ const useConversation = (
     getConvo()
   }, [client, peerAddress])
 
-  const [messages, dispatchMessages] = useReducer(
-    (state: Message[], newMessages: Message[] | undefined) => {
-      // clear out messages when given undefined
-      return newMessages === undefined
-        ? []
-        : state.concat(newMessages.filter(buildMessageDeduper(state)))
-    },
-    []
-  )
-
   useEffect(() => {
-    dispatchMessages(undefined)
     const closeStream = async () => {
       if (!stream) return
       await stream.return()
@@ -51,15 +33,21 @@ const useConversation = (
   useEffect(() => {
     const listMessages = async () => {
       if (!conversation) return
+      console.log('Listing messages for peer address', conversation.peerAddress)
       const msgs = await conversation.messages({ pageSize: 100 })
+      if (dispatchMessages) {
+        dispatchMessages({
+          peerAddress: conversation.peerAddress,
+          messages: msgs,
+        })
+      }
 
-      dispatchMessages(msgs)
       if (onMessageCallback) {
         onMessageCallback()
       }
     }
     listMessages()
-  }, [conversation, onMessageCallback])
+  }, [conversation, dispatchMessages, onMessageCallback])
 
   useEffect(() => {
     const streamMessages = async () => {
@@ -67,14 +55,20 @@ const useConversation = (
       const stream = conversation.streamMessages()
       setStream(stream)
       for await (const msg of stream) {
-        dispatchMessages([msg])
+        if (dispatchMessages) {
+          dispatchMessages({
+            peerAddress: conversation.peerAddress,
+            messages: [msg],
+          })
+        }
+
         if (onMessageCallback) {
           onMessageCallback()
         }
       }
     }
     streamMessages()
-  }, [conversation, onMessageCallback])
+  }, [conversation, peerAddress, dispatchMessages, onMessageCallback])
 
   const handleSend = useCallback(
     async (message: string) => {
@@ -86,7 +80,7 @@ const useConversation = (
 
   return {
     conversation,
-    messages,
+    messages: getMessages(peerAddress),
     sendMessage: handleSend,
   }
 }

--- a/hooks/useMessageStore.ts
+++ b/hooks/useMessageStore.ts
@@ -1,0 +1,43 @@
+import { Message } from '@xmtp/xmtp-js'
+import { useCallback, useReducer } from 'react'
+import { MessageStoreEvent } from '../contexts/xmtp'
+
+type MessageDeduper = (message: Message) => boolean
+type MessageStore = { [address: string]: Message[] }
+
+const buildMessageDeduper = (state: Message[]): MessageDeduper => {
+  const existingMessageKeys = state.map((msg) => msg.id)
+
+  return (msg: Message) => existingMessageKeys.indexOf(msg.id) === -1
+}
+
+const useMessageStore = () => {
+  const [messageStore, dispatchMessages] = useReducer(
+    (state: MessageStore, { peerAddress, messages }: MessageStoreEvent) => {
+      const existing = state[peerAddress] || []
+      const newMessages = messages.filter(buildMessageDeduper(existing))
+      if (!newMessages.length) {
+        return state
+      }
+      console.log('Dispatching new messages for peer address', peerAddress)
+
+      return {
+        ...state,
+        [peerAddress]: existing.concat(newMessages),
+      }
+    },
+    {}
+  )
+
+  const getMessages = useCallback(
+    (peerAddress: string) => messageStore[peerAddress] || [],
+    [messageStore]
+  )
+
+  return {
+    getMessages,
+    dispatchMessages,
+  }
+}
+
+export default useMessageStore


### PR DESCRIPTION
## Background
In the spirit of "making the protocol look good", I wanted to improve the responsiveness of the chat app. This creates a centralized message store, so that when you switch between chats the message list is instantly available (assuming the fetch from the sidebar has already completed).

## Contents
- Creates the new message store and includes it in the XMTP context
- Uses that message store in the `useConversation` hook

## Up next
ListMessages is getting called more often than I would expect. Need to figure out why.

I also added some logging messages which we'll eventually want to remove.