### PR TITLE
Clean up next.config.js

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="next" />
+/// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,21 +1,14 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const optimizedImages = require('next-optimized-images')
-// // eslint-disable-next-line @typescript-eslint/no-var-requires
-// const path = require('path')
-
 /** @type {import('next').NextConfig} */
-const nextConfig = optimizedImages({
+const nextConfig = {
   reactStrictMode: true,
-  images: {
-    disableStaticImages: true,
-  },
-  handleImages: ['jpeg', 'png', 'svg'],
   webpack: (config, { isServer }) => {
     if (!isServer) {
+      // Fixes npm packages that depend on `fs` module
+      // https://github.com/vercel/next.js/issues/7755#issuecomment-937721514
       config.resolve.fallback.fs = false
     }
     return config
   },
-})
+}
 
 module.exports = nextConfig


### PR DESCRIPTION
This PR removes the unused optimize images code from `next.config.js` and links to a reference with context about the fs config.

Related to https://github.com/xmtp/xmtp-js/pull/78