### PR TITLE
fix: send button svg rendering

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const optimizedImages = require('next-optimized-images')
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig = optimizedImages({
   reactStrictMode: true,
+  handleImages: ['svg'],
   webpack: (config, { isServer }) => {
     if (!isServer) {
       // Fixes npm packages that depend on `fs` module
@@ -9,6 +13,6 @@ const nextConfig = {
     }
     return config
   },
-}
+})
 
 module.exports = nextConfig


### PR DESCRIPTION
Reverts parts of https://github.com/xmtp/chat/pull/33/, removed a dependency that is used to render the send arrow SVGs in the message composer bar.

This was causing the arrow to appear missing:

<img width="60" alt="CleanShot 2022-03-01 at 22 41 41@2x" src="https://user-images.githubusercontent.com/510695/156309022-12c1bc70-5811-4b1a-b96f-46a94c65a316.png">

This issue would not have been visible until a server restart.
