### PR TITLE
fix: sort conversations on initial load

### DIFF
--- a/components/ConversationsList.tsx
+++ b/components/ConversationsList.tsx
@@ -4,9 +4,11 @@ import Address from './Address'
 import { useRouter } from 'next/router'
 import { Conversation } from '@xmtp/xmtp-js/dist/types/src/conversations'
 import useConversation from '../hooks/useConversation'
+import { XmtpContext } from '../contexts/xmtp'
 import { Message } from '@xmtp/xmtp-js'
 import useWallet from '../hooks/useWallet'
 import Avatar from './Avatar'
+import { useContext } from 'react'
 
 type ConversationsListProps = {
   conversations: Conversation[]
@@ -30,6 +32,9 @@ const ConversationTile = ({
   const { messages } = useConversation(conversation.peerAddress)
   const latestMessage = getLatestMessage(messages)
   const path = `/dm/${conversation.peerAddress}`
+  if (!latestMessage) {
+    return <div />
+  }
   return (
     <Link href={path} key={conversation.peerAddress}>
       <a onClick={onClick}>
@@ -90,10 +95,25 @@ const ConversationsList = ({
 }: ConversationsListProps): JSX.Element => {
   const router = useRouter()
 
+  const { getMessages } = useContext(XmtpContext)
+
+  const orderByLatestMessage = (
+    convoA: Conversation,
+    convoB: Conversation
+  ): number => {
+    const convoAMessages = getMessages(convoA.peerAddress)
+    const convoBMessages = getMessages(convoB.peerAddress)
+    const convoALastMessageDate =
+      getLatestMessage(convoAMessages)?.sent || new Date()
+    const convoBLastMessageDate =
+      getLatestMessage(convoBMessages)?.sent || new Date()
+    return convoALastMessageDate < convoBLastMessageDate ? 1 : -1
+  }
+
   return (
     <div>
       {conversations &&
-        conversations.map((convo) => {
+        conversations.sort(orderByLatestMessage).map((convo) => {
           const isSelected =
             router.query.recipientWalletAddr == convo.peerAddress
           return (

--- a/components/ConversationsList.tsx
+++ b/components/ConversationsList.tsx
@@ -27,13 +27,13 @@ const ConversationTile = ({
   conversation,
   isSelected,
   onClick,
-}: ConversationTileProps): JSX.Element => {
+}: ConversationTileProps): JSX.Element | null => {
   const { lookupAddress } = useWallet()
   const { messages } = useConversation(conversation.peerAddress)
   const latestMessage = getLatestMessage(messages)
   const path = `/dm/${conversation.peerAddress}`
   if (!latestMessage) {
-    return <div />
+    return null
   }
   return (
     <Link href={path} key={conversation.peerAddress}>

--- a/components/ConversationsList.tsx
+++ b/components/ConversationsList.tsx
@@ -94,9 +94,7 @@ const ConversationsList = ({
   conversations,
 }: ConversationsListProps): JSX.Element => {
   const router = useRouter()
-
   const { getMessages } = useContext(XmtpContext)
-
   const orderByLatestMessage = (
     convoA: Conversation,
     convoB: Conversation
@@ -109,7 +107,6 @@ const ConversationsList = ({
       getLatestMessage(convoBMessages)?.sent || new Date()
     return convoALastMessageDate < convoBLastMessageDate ? 1 : -1
   }
-
   return (
     <div>
       {conversations &&

--- a/components/XmtpProvider.tsx
+++ b/components/XmtpProvider.tsx
@@ -59,7 +59,7 @@ export const XmtpProvider: React.FC = ({ children }) => {
       console.log('Listing conversations')
       setLoadingConversations(true)
       const convos = await client.conversations.list()
-      convos.forEach(async (convo: Conversation) => {
+      convos.forEach((convo: Conversation) => {
         dispatchConversations([convo])
       })
       setLoadingConversations(false)

--- a/components/XmtpProvider.tsx
+++ b/components/XmtpProvider.tsx
@@ -77,13 +77,18 @@ export const XmtpProvider: React.FC = ({ children }) => {
       console.log('Listing conversations')
       setLoadingConversations(true)
       const convos = await client.conversations.list()
-      convos.forEach((convo: Conversation) => {
+      convos.forEach(async (convo: Conversation) => {
+        const msgs = await convo.messages({ pageSize: 100 })
+        dispatchMessages({
+          peerAddress: convo.peerAddress,
+          messages: msgs,
+        })
         dispatchConversations([convo])
       })
       setLoadingConversations(false)
     }
     listConversations()
-  }, [client, walletAddress])
+  }, [client, walletAddress, dispatchMessages])
 
   useEffect(() => {
     const streamConversations = async () => {

--- a/components/XmtpProvider.tsx
+++ b/components/XmtpProvider.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useReducer, useState } from 'react'
-import { Conversation, Message } from '@xmtp/xmtp-js'
+import { Conversation } from '@xmtp/xmtp-js'
 import { Client } from '@xmtp/xmtp-js'
 import { Signer } from 'ethers'
 import { XmtpContext, XmtpContextType } from '../contexts/xmtp'
@@ -13,22 +13,6 @@ export const XmtpProvider: React.FC = ({ children }) => {
   const [loadingConversations, setLoadingConversations] =
     useState<boolean>(false)
 
-  const getLatestMessage = (messages: Message[]): Message | null =>
-    messages.length ? messages[messages.length - 1] : null
-
-  const orderByLatestMessage = (
-    convoA: Conversation,
-    convoB: Conversation
-  ): number => {
-    const convoAMessages = getMessages(convoA.peerAddress)
-    const convoBMessages = getMessages(convoB.peerAddress)
-    const convoALastMessageDate =
-      getLatestMessage(convoAMessages)?.sent || new Date()
-    const convoBLastMessageDate =
-      getLatestMessage(convoBMessages)?.sent || new Date()
-    return convoALastMessageDate < convoBLastMessageDate ? 1 : -1
-  }
-
   const [conversations, dispatchConversations] = useReducer(
     (state: Conversation[], newConvos: Conversation[] | undefined) => {
       if (newConvos === undefined) {
@@ -40,9 +24,7 @@ export const XmtpProvider: React.FC = ({ children }) => {
             return convo.peerAddress === otherConvo.peerAddress
           }) < 0 && convo.peerAddress != client?.address
       )
-      return newConvos === undefined
-        ? []
-        : state.concat(newConvos).sort(orderByLatestMessage)
+      return newConvos === undefined ? [] : state.concat(newConvos)
     },
     []
   )
@@ -78,17 +60,12 @@ export const XmtpProvider: React.FC = ({ children }) => {
       setLoadingConversations(true)
       const convos = await client.conversations.list()
       convos.forEach(async (convo: Conversation) => {
-        const msgs = await convo.messages({ pageSize: 100 })
-        dispatchMessages({
-          peerAddress: convo.peerAddress,
-          messages: msgs,
-        })
         dispatchConversations([convo])
       })
       setLoadingConversations(false)
     }
     listConversations()
-  }, [client, walletAddress, dispatchMessages])
+  }, [client, walletAddress])
 
   useEffect(() => {
     const streamConversations = async () => {


### PR DESCRIPTION
## Problem

#50 properly sorts conversations when new messages are streamed in, but not on initial load. This is because `listConversations` initially dispatches conversations into storage before having dispatched any associated messages. #50 is just sorting empty conversations at this point.

## Solution

- Move sorting logic to the `ConversationsList` component so that it can be applied as messages come in.
- Hide conversation tiles from view until their messages have been loaded.

