### PR TITLE
fix: default .env file should be ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
+.env
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
Since [the readme file references](https://github.com/xmtp/example-chat-react/blob/main/README.md?plain=1#L23) `.env` instead of `.env.local`, this file should possibly be ignored via `.gitignore` by default (to prevent unintentionally committing secrets). 