### PR TITLE
Fix test warnings

### DIFF
--- a/components/AddressInput.test.tsx
+++ b/components/AddressInput.test.tsx
@@ -25,6 +25,7 @@ describe('AddressInput', () => {
   })
 
   it('renders lookup for initial value', async () => {
+    let input: HTMLInputElement | null
     act(() => {
       const { container } = render(
         <AddressInput
@@ -32,12 +33,13 @@ describe('AddressInput', () => {
           lookupAddress={lookupAddress}
         />
       )
-      const input = container.querySelector('input')
-      waitFor(() => expect(input).toHaveAttribute('value', 'foo.eth'))
+      input = container.querySelector('input')
     })
+    waitFor(() => expect(input).toHaveAttribute('value', 'foo.eth'))
   })
 
   it('renders lookup for changed value', async () => {
+    let input: HTMLInputElement | null
     act(() => {
       const rerenderWithInputValue = (value: string) =>
         rerender(
@@ -58,11 +60,11 @@ describe('AddressInput', () => {
           }}
         />
       )
-      const input = container.querySelector('input')
+      input = container.querySelector('input')
       assert.ok(input)
       expect(input).toHaveAttribute('value', '0xbar')
       fireEvent.change(input, { target: { value: '0xfoo' } })
-      waitFor(() => expect(input).toHaveAttribute('value', 'foo.eth'))
     })
+    waitFor(() => expect(input).toHaveAttribute('value', 'foo.eth'))
   })
 })

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,4 @@
-import "@testing-library/jest-dom";
+import '@testing-library/jest-dom'
+import failOnConsole from 'jest-fail-on-console'
+
+failOnConsole()

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "eslint-config-next": "12.0.9",
         "eslint-config-prettier": "^8.3.0",
         "jest": "^27.5.1",
+        "jest-fail-on-console": "^2.4.2",
         "node-localstorage": "^2.2.1",
         "postcss": "^8.4.5",
         "prettier": "^2.5.1",
@@ -10717,6 +10718,85 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-fail-on-console": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jest-fail-on-console/-/jest-fail-on-console-2.4.2.tgz",
+      "integrity": "sha512-CdulWZvfI+cz4+dXQr6p0BhhexFjLnIIBR/7YcpzPXFxrNozAruWkEjR1RU89cd7WXYwckX5ygvHuHQa3NjbOQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-fail-on-console/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-get-type": {
@@ -26662,6 +26742,66 @@
         "@types/node": "*",
         "jest-mock": "^27.5.1",
         "jest-util": "^27.5.1"
+      }
+    },
+    "jest-fail-on-console": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jest-fail-on-console/-/jest-fail-on-console-2.4.2.tgz",
+      "integrity": "sha512-CdulWZvfI+cz4+dXQr6p0BhhexFjLnIIBR/7YcpzPXFxrNozAruWkEjR1RU89cd7WXYwckX5ygvHuHQa3NjbOQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jest-get-type": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-config-next": "12.0.9",
     "eslint-config-prettier": "^8.3.0",
     "jest": "^27.5.1",
+    "jest-fail-on-console": "^2.4.2",
     "node-localstorage": "^2.2.1",
     "postcss": "^8.4.5",
     "prettier": "^2.5.1",


### PR DESCRIPTION
While running tests in this repo I noticed that there were a couple of big red warnings about updates not being wrapped in `act()`, which at first looked like errors, but it the tests did actually pass, so you could argue that it's just noise, but noise that ideally shouldn't be there. So this PR fixes the 2 issues causing those warnings, and also updates the jest config to fail on warnings like this.