### PR TITLE
Use 4.0 version of client SDK

### DIFF
--- a/components/XmtpProvider.tsx
+++ b/components/XmtpProvider.tsx
@@ -70,7 +70,7 @@ export const XmtpProvider: React.FC = ({ children }) => {
   useEffect(() => {
     const streamConversations = async () => {
       if (!client) return
-      const stream = client.conversations.stream()
+      const stream = await client.conversations.stream()
       for await (const convo of stream) {
         dispatchConversations([convo])
       }

--- a/hooks/useConversation.ts
+++ b/hooks/useConversation.ts
@@ -55,7 +55,7 @@ const useConversation = (
   useEffect(() => {
     const streamMessages = async () => {
       if (!conversation) return
-      const stream = conversation.streamMessages()
+      const stream = await conversation.streamMessages()
       setStream(stream)
       for await (const msg of stream) {
         if (dispatchMessages) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@headlessui/react": "^1.4.3",
         "@heroicons/react": "^1.0.5",
-        "@xmtp/xmtp-js": "^3.0.0",
+        "@xmtp/xmtp-js": "^4.0.0",
         "ethers": "^5.5.3",
         "imagemin-svgo": "^9.0.0",
         "next": "12.0.9",
@@ -47,6 +47,9 @@
         "walletlink": "^2.4.6",
         "web3modal": "^1.9.5"
       }
+    },
+    "../../../../xmtp-js-sdk": {
+      "extraneous": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.1.2",
@@ -2184,9 +2187,9 @@
       }
     },
     "node_modules/@leichtgewicht/ip-codec": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
-      "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "node_modules/@metamask/safe-event-emitter": {
       "version": "2.0.0",
@@ -2205,11 +2208,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
     },
     "node_modules/@next/env": {
       "version": "12.0.9",
@@ -2450,7 +2448,7 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
@@ -2465,12 +2463,12 @@
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -2479,27 +2477,27 @@
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.1.0",
@@ -3025,9 +3023,9 @@
       "dev": true
     },
     "node_modules/@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -3092,9 +3090,9 @@
       }
     },
     "node_modules/@types/retry": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
@@ -3869,15 +3867,15 @@
       }
     },
     "node_modules/@xmtp/xmtp-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-3.0.0.tgz",
-      "integrity": "sha512-Iaswvm8w2vI5zUhmrT47KcD6QSJstHYNu4ZXSrZYX+ZtsMdwV1BPYyrqTXnT3fqdUAkoGtHBDoEZO5DFOfNN8w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-4.0.0.tgz",
+      "integrity": "sha512-EvDbA5gbKZ8c/Qp2fL7/q0P2RFgjjXKINiJxk5jGS0kfSOoenwquWohVElceyywRCIGawRVnbAraupjiSz31Hw==",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
         "cross-fetch": "^3.1.5",
         "ethers": "^5.5.3",
-        "js-waku": "^0.18",
+        "js-waku": "^0.24.0",
         "protobufjs": "^6.11.2"
       }
     },
@@ -6370,15 +6368,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "node_modules/ecies-geth": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ecies-geth/-/ecies-geth-1.6.3.tgz",
-      "integrity": "sha512-RAZs5p0MZLGWXt3weAHjefnWzJwTDvMw8GizSHhPNM8HkGDkRnOjbJtN613BD+/EOPaTP5j7bwwd83WhJq+5Ew==",
-      "dependencies": {
-        "elliptic": "^6.5.4",
-        "secp256k1": "^4.0.3"
-      }
     },
     "node_modules/electron-fetch": {
       "version": "1.7.4",
@@ -9492,9 +9481,9 @@
       }
     },
     "node_modules/ipfs-utils": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.5.tgz",
-      "integrity": "sha512-GXWfsq/nKtwkcTI4+KGc4CU9EFXjtkWaGcFAsnm177kAhA0Fnn8aWNRaF/C0xFraUIl1wTAUTWkaGKigVyfsTw==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.6.tgz",
+      "integrity": "sha512-/WfdwOIiJVb3uqfKRQ9Eo+vCEKsDgp7h4Pdc37MRwAiFciZ7xKAkEqsfXubV0VQi8x5jWTifeHn8WEPBLL451w==",
       "dependencies": {
         "any-signal": "^3.0.0",
         "buffer": "^6.0.1",
@@ -11867,29 +11856,35 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-waku": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.18.0.tgz",
-      "integrity": "sha512-ooqSnDTZqodWFS6RKtqwTKD5pGZ3VG5AWBTD2Gt7iLdTJxTRE1JHUKm3IQmU8lXq6QEBtdisN76Vl9syDir9wg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.24.0.tgz",
+      "integrity": "sha512-8l7/WuadaaGy6XmVKutZpJ61JohbBe8WamJUtNiTd8WdxhBuz/rXh5RUiD8mjiiG8kEzQ+3+E68rvIpb/+BbXw==",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^5.0.0",
         "@ethersproject/rlp": "^5.5.0",
+        "@noble/secp256k1": "^1.3.4",
         "debug": "^4.3.1",
         "dns-query": "^0.8.0",
-        "ecies-geth": "^1.5.2",
         "hi-base32": "^0.5.1",
         "it-concat": "^2.0.0",
         "it-length-prefixed": "^5.0.2",
+        "it-pipe": "^1.1.0",
         "js-sha3": "^0.8.0",
         "libp2p": "^0.36.2",
         "libp2p-bootstrap": "^0.14.0",
-        "libp2p-gossipsub": "^0.13.0",
+        "libp2p-crypto": "^0.21.2",
+        "libp2p-gossipsub": "0.13.0",
+        "libp2p-interfaces": "^4.0.6",
         "libp2p-mplex": "^0.10.4",
         "libp2p-websockets": "^0.16.1",
+        "long": "^4.0.0",
         "multiaddr": "^10.0.1",
-        "multihashes": "^4.0.3",
+        "multiformats": "^9.6.5",
+        "peer-id": "^0.16.0",
         "protobufjs": "^6.8.8",
-        "secp256k1": "^4.0.2",
-        "uuid": "^8.3.2"
+        "uint8arrays": "^3.0.0",
+        "uuid": "^8.3.2",
+        "varint": "^6.0.0"
       },
       "engines": {
         "node": ">=16"
@@ -11911,7 +11906,7 @@
     "node_modules/jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jsdom": {
       "version": "16.7.0",
@@ -13022,42 +13017,10 @@
         "multiaddr": "^10.0.0"
       }
     },
-    "node_modules/multibase": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dependencies": {
-        "@multiformats/base-x": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/multiformats": {
-      "version": "9.6.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.4.tgz",
-      "integrity": "sha512-fCCB6XMrr6CqJiHNjfFNGT0v//dxOBMrOMqUIzpPc/mmITweLEyhvMpY9bF+jZ9z3vaMAau5E8B68DW77QMXkg=="
-    },
-    "node_modules/multihashes": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-      "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-      "dependencies": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^3.0.0",
-        "varint": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/multihashes/node_modules/varint": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+      "version": "9.6.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.5.tgz",
+      "integrity": "sha512-vMwf/FUO+qAPvl3vlSZEgEVFY/AxeZq5yg761ScF3CZsXgmTi/HGkicUiNN0CI4PW8FiY2P0OLklOcmQjdQJhw=="
     },
     "node_modules/multistream-select": {
       "version": "3.0.2",
@@ -13252,7 +13215,8 @@
     "node_modules/node-addon-api": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "dev": true
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -13293,9 +13257,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -13304,6 +13268,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
       "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "dev": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -13868,11 +13833,11 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-      "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "dependencies": {
-        "@types/retry": "^0.12.0",
+        "@types/retry": "0.12.0",
         "retry": "^0.13.1"
       },
       "engines": {
@@ -14402,9 +14367,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -15344,6 +15309,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
       "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "elliptic": "^6.5.4",
@@ -18045,11 +18011,15 @@
       }
     },
     "node_modules/wherearewe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.1.tgz",
-      "integrity": "sha512-K77B01OHS3MqBQAMh1o51g0hwKJpj+NgF9YLZPnqgK0xhKSexxlvCXVt3sL/0+0V73Qwni2n0licJv9KpFbtOw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.2.tgz",
+      "integrity": "sha512-HyLZ7n1Yox+w1qWaFEgP/sMs5D7ka2UXmoVNaY0XzbEHLGljo4ScBchYm6cWRYNO33tmFX3Mgg4BiZkDOjihyw==",
       "dependencies": {
         "is-electron": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/which": {
@@ -19795,9 +19765,9 @@
       }
     },
     "@leichtgewicht/ip-codec": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
-      "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "@metamask/safe-event-emitter": {
       "version": "2.0.0",
@@ -19813,11 +19783,6 @@
         "call-me-maybe": "^1.0.1",
         "glob-to-regexp": "^0.3.0"
       }
-    },
-    "@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
     },
     "@next/env": {
       "version": "12.0.9",
@@ -19938,7 +19903,7 @@
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
@@ -19953,12 +19918,12 @@
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -19967,27 +19932,27 @@
     "@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@rushstack/eslint-patch": {
       "version": "1.1.0",
@@ -20447,9 +20412,9 @@
       "dev": true
     },
     "@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/minimatch": {
       "version": "3.0.5",
@@ -20514,9 +20479,9 @@
       }
     },
     "@types/retry": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
     },
     "@types/scheduler": {
       "version": "0.16.2",
@@ -21159,15 +21124,15 @@
       }
     },
     "@xmtp/xmtp-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-3.0.0.tgz",
-      "integrity": "sha512-Iaswvm8w2vI5zUhmrT47KcD6QSJstHYNu4ZXSrZYX+ZtsMdwV1BPYyrqTXnT3fqdUAkoGtHBDoEZO5DFOfNN8w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-4.0.0.tgz",
+      "integrity": "sha512-EvDbA5gbKZ8c/Qp2fL7/q0P2RFgjjXKINiJxk5jGS0kfSOoenwquWohVElceyywRCIGawRVnbAraupjiSz31Hw==",
       "requires": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
         "cross-fetch": "^3.1.5",
         "ethers": "^5.5.3",
-        "js-waku": "^0.18",
+        "js-waku": "^0.24.0",
         "protobufjs": "^6.11.2"
       }
     },
@@ -23197,15 +23162,6 @@
           "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
           "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
         }
-      }
-    },
-    "ecies-geth": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ecies-geth/-/ecies-geth-1.6.3.tgz",
-      "integrity": "sha512-RAZs5p0MZLGWXt3weAHjefnWzJwTDvMw8GizSHhPNM8HkGDkRnOjbJtN613BD+/EOPaTP5j7bwwd83WhJq+5Ew==",
-      "requires": {
-        "elliptic": "^6.5.4",
-        "secp256k1": "^4.0.3"
       }
     },
     "electron-fetch": {
@@ -25730,9 +25686,9 @@
       "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
     },
     "ipfs-utils": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.5.tgz",
-      "integrity": "sha512-GXWfsq/nKtwkcTI4+KGc4CU9EFXjtkWaGcFAsnm177kAhA0Fnn8aWNRaF/C0xFraUIl1wTAUTWkaGKigVyfsTw==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-9.0.6.tgz",
+      "integrity": "sha512-/WfdwOIiJVb3uqfKRQ9Eo+vCEKsDgp7h4Pdc37MRwAiFciZ7xKAkEqsfXubV0VQi8x5jWTifeHn8WEPBLL451w==",
       "requires": {
         "any-signal": "^3.0.0",
         "buffer": "^6.0.1",
@@ -27534,29 +27490,35 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-waku": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.18.0.tgz",
-      "integrity": "sha512-ooqSnDTZqodWFS6RKtqwTKD5pGZ3VG5AWBTD2Gt7iLdTJxTRE1JHUKm3IQmU8lXq6QEBtdisN76Vl9syDir9wg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.24.0.tgz",
+      "integrity": "sha512-8l7/WuadaaGy6XmVKutZpJ61JohbBe8WamJUtNiTd8WdxhBuz/rXh5RUiD8mjiiG8kEzQ+3+E68rvIpb/+BbXw==",
       "requires": {
         "@chainsafe/libp2p-noise": "^5.0.0",
         "@ethersproject/rlp": "^5.5.0",
+        "@noble/secp256k1": "^1.3.4",
         "debug": "^4.3.1",
         "dns-query": "^0.8.0",
-        "ecies-geth": "^1.5.2",
         "hi-base32": "^0.5.1",
         "it-concat": "^2.0.0",
         "it-length-prefixed": "^5.0.2",
+        "it-pipe": "^1.1.0",
         "js-sha3": "^0.8.0",
         "libp2p": "^0.36.2",
         "libp2p-bootstrap": "^0.14.0",
-        "libp2p-gossipsub": "^0.13.0",
+        "libp2p-crypto": "^0.21.2",
+        "libp2p-gossipsub": "0.13.0",
+        "libp2p-interfaces": "^4.0.6",
         "libp2p-mplex": "^0.10.4",
         "libp2p-websockets": "^0.16.1",
+        "long": "^4.0.0",
         "multiaddr": "^10.0.1",
-        "multihashes": "^4.0.3",
+        "multiformats": "^9.6.5",
+        "peer-id": "^0.16.0",
         "protobufjs": "^6.8.8",
-        "secp256k1": "^4.0.2",
-        "uuid": "^8.3.2"
+        "uint8arrays": "^3.0.0",
+        "uuid": "^8.3.2",
+        "varint": "^6.0.0"
       }
     },
     "js-yaml": {
@@ -27572,7 +27534,7 @@
     "jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "jsdom": {
       "version": "16.7.0",
@@ -28552,35 +28514,10 @@
         "multiaddr": "^10.0.0"
       }
     },
-    "multibase": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-      "requires": {
-        "@multiformats/base-x": "^4.0.1"
-      }
-    },
     "multiformats": {
-      "version": "9.6.4",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.4.tgz",
-      "integrity": "sha512-fCCB6XMrr6CqJiHNjfFNGT0v//dxOBMrOMqUIzpPc/mmITweLEyhvMpY9bF+jZ9z3vaMAau5E8B68DW77QMXkg=="
-    },
-    "multihashes": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-      "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-      "requires": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^3.0.0",
-        "varint": "^5.0.2"
-      },
-      "dependencies": {
-        "varint": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-        }
-      }
+      "version": "9.6.5",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.5.tgz",
+      "integrity": "sha512-vMwf/FUO+qAPvl3vlSZEgEVFY/AxeZq5yg761ScF3CZsXgmTi/HGkicUiNN0CI4PW8FiY2P0OLklOcmQjdQJhw=="
     },
     "multistream-select": {
       "version": "3.0.2",
@@ -28723,7 +28660,8 @@
     "node-addon-api": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
+      "dev": true
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -28755,14 +28693,15 @@
       }
     },
     "node-forge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-gyp-build": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "dev": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -29203,11 +29142,11 @@
       "integrity": "sha512-paHV8NUz8zDHu5lhr/ngGWQiW067DK/+IbJ+RfZ4k+s8y4EKyYCz8pGYWjxCg35eHztpJAt+NUgvN4L+GCbPlg=="
     },
     "p-retry": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-      "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
       "requires": {
-        "@types/retry": "^0.12.0",
+        "@types/retry": "0.12.0",
         "retry": "^0.13.1"
       }
     },
@@ -29607,9 +29546,9 @@
       }
     },
     "protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -30334,6 +30273,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
       "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
+      "dev": true,
       "requires": {
         "elliptic": "^6.5.4",
         "node-addon-api": "^2.0.0",
@@ -32550,9 +32490,9 @@
       }
     },
     "wherearewe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.1.tgz",
-      "integrity": "sha512-K77B01OHS3MqBQAMh1o51g0hwKJpj+NgF9YLZPnqgK0xhKSexxlvCXVt3sL/0+0V73Qwni2n0licJv9KpFbtOw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.2.tgz",
+      "integrity": "sha512-HyLZ7n1Yox+w1qWaFEgP/sMs5D7ka2UXmoVNaY0XzbEHLGljo4ScBchYm6cWRYNO33tmFX3Mgg4BiZkDOjihyw==",
       "requires": {
         "is-electron": "^2.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@headlessui/react": "^1.4.3",
     "@heroicons/react": "^1.0.5",
-    "@xmtp/xmtp-js": "^3.0.0",
+    "@xmtp/xmtp-js": "^4.0.0",
     "ethers": "^5.5.3",
     "imagemin-svgo": "^9.0.0",
     "next": "12.0.9",


### PR DESCRIPTION
## Summary
Switch to the 4.0 version of the client SDK, which uses the Waku Filter protocol for message streaming and connects to the `dev` network by default.