### PR TITLE
Add CyberConnect and LIT filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 scratch
 
 .npmrc
+pnpm-lock.yaml

--- a/components/App.tsx
+++ b/components/App.tsx
@@ -1,4 +1,5 @@
 import XmtpProvider from './XmtpProvider'
+import CyberConnectProvider from './CyberConnectProvider'
 import Layout from '../components/Layout'
 import { WalletProvider } from './WalletProvider'
 
@@ -10,7 +11,9 @@ function App({ children }: AppProps) {
   return (
     <WalletProvider>
       <XmtpProvider>
-        <Layout>{children}</Layout>
+        <CyberConnectProvider>
+          <Layout>{children}</Layout>
+        </CyberConnectProvider>
       </XmtpProvider>
     </WalletProvider>
   )

--- a/components/Conversation/MessagesList.tsx
+++ b/components/Conversation/MessagesList.tsx
@@ -25,7 +25,13 @@ const formatDate = (d?: Date) =>
 
 const MessageTile = ({ message, isSender }: MessageTileProps): JSX.Element => (
   <div className="flex items-start mx-auto mb-4">
-    <Avatar peerAddress={message.senderAddress as string} />
+    <a
+      href={`http://localhost:3333/${message.senderAddress}`}
+      target="_blank"
+      rel="noreferrer"
+    >
+      <Avatar peerAddress={message.senderAddress as string} />
+    </a>
     <div className="ml-2">
       <div>
         <AddressPill
@@ -96,7 +102,7 @@ const MessagesList = ({
               const dateHasChanged = !isOnSameDay(lastMessageDate, msg.sent)
               lastMessageDate = msg.sent
               return dateHasChanged
-                ? [<DateDivider date={msg.sent} key={msg.id} />, tile]
+                ? [<DateDivider date={msg.sent} key={`date-${msg.id}`} />, tile]
                 : tile
             })}
             <div ref={messagesEndRef} />

--- a/components/ConversationCategory.tsx
+++ b/components/ConversationCategory.tsx
@@ -1,0 +1,63 @@
+import { classNames } from '../helpers'
+
+const tabs = [
+  { name: 'All', href: '#', count: '52', current: true },
+  { name: 'By NFT', href: '#', count: '6', current: false },
+  { name: 'By Space', href: '#', count: '4', current: false },
+]
+
+export default function ConversationCategory() {
+  return (
+    <div className="">
+      <div className="sm:hidden">
+        <label htmlFor="tabs" className="sr-only">
+          Select a tab
+        </label>
+        {/* Use an "onChange" listener to redirect the user to the selected tab URL. */}
+        <select
+          id="tabs"
+          name="tabs"
+          className="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
+          defaultValue={tabs.find((tab) => tab.current).name}
+        >
+          {tabs.map((tab) => (
+            <option key={tab.name}>{tab.name}</option>
+          ))}
+        </select>
+      </div>
+      <div className="hidden sm:block">
+        <div className="border-b border-gray-200">
+          <nav className="-mb-px flex space-x-8 px-2" aria-label="Tabs">
+            {tabs.map((tab) => (
+              <a
+                key={tab.name}
+                href="#"
+                className={classNames(
+                  tab.current
+                    ? 'border-indigo-500 text-indigo-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-200',
+                  'whitespace-nowrap flex py-4 px-1 border-b-2 font-medium text-sm'
+                )}
+                aria-current={tab.current ? 'page' : undefined}
+              >
+                {tab.name}
+                {tab.count ? (
+                  <span
+                    className={classNames(
+                      tab.current
+                        ? 'bg-indigo-100 text-indigo-600'
+                        : 'bg-gray-100 text-gray-900',
+                      'hidden ml-3 py-0.5 px-2.5 rounded-full text-xs font-medium md:inline-block'
+                    )}
+                  >
+                    {tab.count}
+                  </span>
+                ) : null}
+              </a>
+            ))}
+          </nav>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/ConversationCategory.tsx
+++ b/components/ConversationCategory.tsx
@@ -17,7 +17,7 @@ export default function ConversationCategory() {
         <select
           id="tabs"
           name="tabs"
-          className="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md"
+          className="block w-full py-2 pl-3 pr-10 text-base border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
           defaultValue={tabs.find((tab) => tab.current).name}
         >
           {tabs.map((tab) => (
@@ -27,7 +27,7 @@ export default function ConversationCategory() {
       </div>
       <div className="hidden sm:block">
         <div className="border-b border-gray-200">
-          <nav className="-mb-px flex space-x-8 px-2" aria-label="Tabs">
+          <nav className="flex px-2 -mb-px space-x-8" aria-label="Tabs">
             {tabs.map((tab) => (
               <a
                 key={tab.name}

--- a/components/ConversationFilter.tsx
+++ b/components/ConversationFilter.tsx
@@ -1,90 +1,104 @@
 import { classNames } from '../helpers'
 import { Fragment, useEffect, useState } from 'react'
 import { Listbox, Transition } from '@headlessui/react'
-import { CheckIcon, SelectorIcon } from '@heroicons/react/solid'
+import { CheckIcon, SelectorIcon, FilterIcon } from '@heroicons/react/solid'
+import ConversationFilterSlideOver from './ConversationFilterSlideOver'
+import LitJsSdk from 'lit-js-sdk'
+
 import useCyberConnect from '../hooks/useCyberConnect'
 
 export default function ConversationFilter() {
   const { filterBy, updateFilterBy } = useCyberConnect()
-  const items = [
-    'friends',
-    'followings',
-    'followers',
-    'all',
-    // 'Archive',
-  ]
+  const items = ['friends', 'followings', 'followers', 'all']
+  const [open, setOpen] = useState(true)
+
   useEffect(() => {
     if (!filterBy) {
       updateFilterBy(items[0])
     }
   })
   return (
-    <Listbox value={filterBy} onChange={updateFilterBy}>
-      {({ open }) => (
-        <>
-          <Listbox.Label className="block text-sm font-medium text-gray-700 mr-2">
-            Filter By:
-          </Listbox.Label>
-          <div className="relative w-40">
-            <Listbox.Button className="bg-white relative w-full border border-gray-300 rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-pointer focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
-              <span className="block truncate">{filterBy}</span>
-              <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                <SelectorIcon
-                  className="h-5 w-5 text-gray-400"
-                  aria-hidden="true"
-                />
-              </span>
-            </Listbox.Button>
+    <div className="w-full">
+      <div className="flex justify-between w-full py-2 bg--300">
+        <div className="flex justify-between flex-1">
+          <Listbox value={filterBy} onChange={updateFilterBy}>
+            {({ open }) => (
+              <>
+                <Listbox.Label className="flex items-center w-6 mr-2 text-sm font-medium text-gray-700"></Listbox.Label>
+                <div className="relative w-40">
+                  <Listbox.Button className="relative w-full py-2 pl-3 pr-10 text-left bg-white border border-gray-300 rounded-md shadow-sm cursor-pointer focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+                    <span className="block truncate">{filterBy}</span>
+                    <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+                      <SelectorIcon
+                        className="w-5 h-5 text-gray-400"
+                        aria-hidden="true"
+                      />
+                    </span>
+                  </Listbox.Button>
 
-            <Transition
-              show={open}
-              as={Fragment}
-              leave="transition ease-in duration-100"
-              leaveFrom="opacity-100"
-              leaveTo="opacity-0"
-            >
-              <Listbox.Options className="absolute z-10 mt-1 w-full bg-white shadow-lg max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm">
-                {items.map((name) => (
-                  <Listbox.Option
-                    key={name}
-                    className={({ active }) =>
-                      classNames(
-                        active ? 'text-white bg-indigo-600' : 'text-gray-900',
-                        'cursor-pointer select-none relative py-2 pl-3 pr-9'
-                      )
-                    }
-                    value={name}
+                  <Transition
+                    show={open}
+                    as={Fragment}
+                    leave="transition ease-in duration-100"
+                    leaveFrom="opacity-100"
+                    leaveTo="opacity-0"
                   >
-                    {({ selected, active }) => (
-                      <>
-                        <span
-                          className={classNames(
-                            selected ? 'font-semibold' : 'font-normal',
-                            'block truncate'
-                          )}
+                    <Listbox.Options className="absolute z-10 w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+                      {items.map((name) => (
+                        <Listbox.Option
+                          key={name}
+                          className={({ active }) =>
+                            classNames(
+                              active ? 'text-white bg-p-600' : 'text-gray-900',
+                              'cursor-pointer select-none relative py-2 pl-3 pr-9'
+                            )
+                          }
+                          value={name}
                         >
-                          {name}
-                        </span>
+                          {({ selected, active }) => (
+                            <>
+                              <span
+                                className={classNames(
+                                  selected ? 'font-semibold' : 'font-normal',
+                                  'block truncate'
+                                )}
+                              >
+                                {name}
+                              </span>
 
-                        {selected ? (
-                          <span
-                            className={classNames(
-                              active ? 'text-white' : 'text-indigo-600',
-                              'absolute inset-y-0 right-0 flex items-center pr-4'
-                            )}
-                          >
-                            <CheckIcon className="h-5 w-5" aria-hidden="true" />
-                          </span>
-                        ) : null}
-                      </>
-                    )}
-                  </Listbox.Option>
-                ))}
-              </Listbox.Options>
-            </Transition>
-          </div>
-        </>
-      )}
-    </Listbox>
+                              {selected ? (
+                                <span
+                                  className={classNames(
+                                    active ? 'text-white' : 'text-indigo-600',
+                                    'absolute inset-y-0 right-0 flex items-center pr-4'
+                                  )}
+                                >
+                                  <CheckIcon
+                                    className="w-5 h-5"
+                                    aria-hidden="true"
+                                  />
+                                </span>
+                              ) : null}
+                            </>
+                          )}
+                        </Listbox.Option>
+                      ))}
+                    </Listbox.Options>
+                  </Transition>
+                </div>
+              </>
+            )}
+          </Listbox>
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="inline-flex items-center p-1 text-xs text-indigo-500 border-0 hover:text-indigo-700"
+        >
+          <FilterIcon className="w-6 h-6 " aria-hidden="true" />
+        </button>
+      </div>
+      <ConversationFilterSlideOver onClose={() => setOpen(false)} open={open} />
+    </div>
   )
 }

--- a/components/ConversationFilter.tsx
+++ b/components/ConversationFilter.tsx
@@ -10,7 +10,7 @@ import useCyberConnect from '../hooks/useCyberConnect'
 export default function ConversationFilter() {
   const { filterBy, updateFilterBy } = useCyberConnect()
   const items = ['friends', 'followings', 'followers', 'all']
-  const [open, setOpen] = useState(true)
+  const [open, setOpen] = useState(false)
 
   useEffect(() => {
     if (!filterBy) {

--- a/components/ConversationFilter.tsx
+++ b/components/ConversationFilter.tsx
@@ -1,0 +1,90 @@
+import { classNames } from '../helpers'
+import { Fragment, useEffect, useState } from 'react'
+import { Listbox, Transition } from '@headlessui/react'
+import { CheckIcon, SelectorIcon } from '@heroicons/react/solid'
+import useCyberConnect from '../hooks/useCyberConnect'
+
+export default function ConversationFilter() {
+  const { filterBy, updateFilterBy } = useCyberConnect()
+  const items = [
+    'friends',
+    'followings',
+    'followers',
+    'all',
+    // 'Archive',
+  ]
+  useEffect(() => {
+    if (!filterBy) {
+      updateFilterBy(items[0])
+    }
+  })
+  return (
+    <Listbox value={filterBy} onChange={updateFilterBy}>
+      {({ open }) => (
+        <>
+          <Listbox.Label className="block text-sm font-medium text-gray-700 mr-2">
+            Filter By:
+          </Listbox.Label>
+          <div className="relative w-40">
+            <Listbox.Button className="bg-white relative w-full border border-gray-300 rounded-md shadow-sm pl-3 pr-10 py-2 text-left cursor-pointer focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+              <span className="block truncate">{filterBy}</span>
+              <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+                <SelectorIcon
+                  className="h-5 w-5 text-gray-400"
+                  aria-hidden="true"
+                />
+              </span>
+            </Listbox.Button>
+
+            <Transition
+              show={open}
+              as={Fragment}
+              leave="transition ease-in duration-100"
+              leaveFrom="opacity-100"
+              leaveTo="opacity-0"
+            >
+              <Listbox.Options className="absolute z-10 mt-1 w-full bg-white shadow-lg max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm">
+                {items.map((name) => (
+                  <Listbox.Option
+                    key={name}
+                    className={({ active }) =>
+                      classNames(
+                        active ? 'text-white bg-indigo-600' : 'text-gray-900',
+                        'cursor-pointer select-none relative py-2 pl-3 pr-9'
+                      )
+                    }
+                    value={name}
+                  >
+                    {({ selected, active }) => (
+                      <>
+                        <span
+                          className={classNames(
+                            selected ? 'font-semibold' : 'font-normal',
+                            'block truncate'
+                          )}
+                        >
+                          {name}
+                        </span>
+
+                        {selected ? (
+                          <span
+                            className={classNames(
+                              active ? 'text-white' : 'text-indigo-600',
+                              'absolute inset-y-0 right-0 flex items-center pr-4'
+                            )}
+                          >
+                            <CheckIcon className="h-5 w-5" aria-hidden="true" />
+                          </span>
+                        ) : null}
+                      </>
+                    )}
+                  </Listbox.Option>
+                ))}
+              </Listbox.Options>
+            </Transition>
+          </div>
+        </>
+      )}
+    </Listbox>
+  )
+}

--- a/components/ConversationFilterSlideOver.tsx
+++ b/components/ConversationFilterSlideOver.tsx
@@ -1,0 +1,158 @@
+import { Fragment, useState } from 'react'
+import { Dialog, Transition } from '@headlessui/react'
+import { XIcon } from '@heroicons/react/outline'
+import Selector from './Selector'
+import LitACLItem from './LitACLItem'
+import { PlusCircleIcon } from '@heroicons/react/solid'
+
+export default function ConversationFilterSlideOver(props) {
+  const booleanLogicItems = [
+    { id: 'intersection', name: 'intersection' },
+    { id: 'union', name: 'union' },
+  ]
+  const [booleanLogic, setBooleanLogic] = useState(booleanLogicItems[0])
+
+  const defaultConditionItem = {
+    contractType: 'ERC721',
+    contractAddress: '',
+    comparator: '',
+    number: '',
+  }
+  const [conditionItems, setConditionItems] = useState([
+    { ...defaultConditionItem },
+  ])
+  const doSubmit = async (e) => {
+    e.preventDefault()
+    console.log({
+      booleanLogic,
+      conditionItems,
+    })
+  }
+  return (
+    <Transition.Root show={props.open} as={Fragment}>
+      <Dialog as="div" className="relative z-10" onClose={props.onClose}>
+        {/* The backdrop, rendered as a fixed sibling to the panel container */}
+        <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+
+        <div className="fixed inset-0 overflow-hidden">
+          <div className="absolute inset-y-0 left-0 overflow-hidden">
+            <div className="fixed inset-y-0 left-0 flex max-w-full pr-10 pointer-events-none sm:pr-16">
+              <Transition.Child
+                as={Fragment}
+                enter="transform transition ease-in-out duration-500 sm:duration-700"
+                enterFrom="-translate-x-full"
+                enterTo="translate-x-0"
+                leave="transform transition ease-in-out duration-500 sm:duration-700"
+                leaveFrom="translate-x-0"
+                leaveTo="-translate-x-full"
+              >
+                <Dialog.Panel className="w-screen max-w-4xl pointer-events-auto">
+                  <form className="flex flex-col h-full bg-white divide-y divide-gray-200 shadow-xl">
+                    <div className="flex-1 h-0 overflow-y-auto">
+                      <div className="px-4 py-6 bg-indigo-700 sm:px-6">
+                        <div className="flex items-center justify-between">
+                          <Dialog.Title className="text-lg font-medium text-white">
+                            XMTP LIT Condition Generator
+                          </Dialog.Title>
+                          <div className="flex items-center ml-3 h-7">
+                            <button
+                              type="button"
+                              className="text-indigo-200 bg-indigo-700 rounded-md hover:text-white focus:outline-none focus:ring-2 focus:ring-white"
+                              onClick={props.onClose}
+                            >
+                              <span className="sr-only">Close panel</span>
+                              <XIcon className="w-6 h-6" aria-hidden="true" />
+                            </button>
+                          </div>
+                        </div>
+                        <div className="mt-1">
+                          <p className="text-sm text-indigo-300">
+                            Generate your on-chain conditions to filter who you
+                            want to chat with here. <br />
+                            Have more LIT conditions ideas?{' '}
+                            <a
+                              href="https://twitter.com/Web3HackerNinja"
+                              target="_blank"
+                              rel="noreferrer"
+                              className="text-red-400 hover:underline"
+                            >
+                              Contact US{' '}
+                            </a>{' '}
+                            to add more!
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex flex-col justify-between flex-1">
+                        <div className="px-4 divide-y divide-gray-200 sm:px-6">
+                          <div className="pt-6 pb-5 space-y-6">
+                            {conditionItems.map((item, index) => {
+                              return (
+                                <LitACLItem
+                                  key={index}
+                                  contractType={item.contractType}
+                                  onUpdate={({ key, value }) => {
+                                    conditionItems[index][key] = value
+                                    setConditionItems([...conditionItems])
+                                  }}
+                                  onDelete={() => {
+                                    conditionItems.splice(index, 1)
+                                    setConditionItems([...conditionItems])
+                                  }}
+                                />
+                              )
+                            })}
+
+                            <div className="flex items-center justify-end">
+                              <button
+                                type="button"
+                                className="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                                onClick={() =>
+                                  setConditionItems([
+                                    ...conditionItems,
+                                    { ...defaultConditionItem },
+                                  ])
+                                }
+                              >
+                                <PlusCircleIcon className="w-5 h-5 mr-1 text-white hover:cursor-pointer" />
+                                Add
+                              </button>
+                            </div>
+                          </div>
+                          <div className="flex items-center justify-end pt-4 pb-6 text-sm">
+                            All the LIT conditions should be:
+                            <div className="w-32 ml-2">
+                              <Selector
+                                items={booleanLogicItems}
+                                selected={booleanLogic}
+                                onSelected={(item) => setBooleanLogic(item)}
+                              ></Selector>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex justify-end flex-shrink-0 px-4 py-4">
+                      <button
+                        type="button"
+                        className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                        onClick={props.onClose}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        onClick={(e) => doSubmit(e)}
+                        className="inline-flex justify-center px-4 py-2 ml-4 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                      >
+                        Save
+                      </button>
+                    </div>
+                  </form>
+                </Dialog.Panel>
+              </Transition.Child>
+            </div>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  )
+}

--- a/components/ConversationFilterSlideOver.tsx
+++ b/components/ConversationFilterSlideOver.tsx
@@ -1,12 +1,16 @@
-import { Fragment, useContext } from 'react'
+import { Fragment, useContext, useEffect, useState } from 'react'
 import CyberConnectContext from '../contexts/cyberConnect'
+import { chainItems } from './CyberConnectProvider'
 import { Dialog, Transition } from '@headlessui/react'
 import { XIcon } from '@heroicons/react/outline'
 import Selector from './Selector'
 import LitACLItem from './LitACLItem'
 import { PlusCircleIcon } from '@heroicons/react/solid'
 import { booleanLogicItems } from '../contexts/cyberConnect'
-
+import LitJsSdk from 'lit-js-sdk'
+import useXmtp from '../hooks/useXmtp'
+import { ethers } from 'ethers'
+import { union, intersection } from 'lodash'
 const defaultConditionItem = {
   id: '',
   contractType: 'ERC721',
@@ -16,22 +20,178 @@ const defaultConditionItem = {
 }
 
 export default function ConversationFilterSlideOver(props) {
-  const { booleanLogic, conditionItems, setBooleanLogic, setConditionItems } =
-    useContext(CyberConnectContext)
+  const { conversations } = useXmtp()
+  const [isLoading, setIsLoading] = useState(false)
+
+  const {
+    booleanLogic,
+    conditionItems,
+    setBooleanLogic,
+    setConditionItems,
+    chainItem,
+    setChainItem,
+    allLitValidateAddress,
+    setAllLitValidateAddress,
+  } = useContext(CyberConnectContext)
+
+  const addItem = () => {
+    setConditionItems([
+      ...conditionItems,
+      {
+        ...defaultConditionItem,
+        id: Date.now() + '' + Math.floor(Math.random() * 100000),
+      },
+    ])
+  }
 
   const deleteItem = (id) => {
     const items = conditionItems.filter((item) => item.id !== id)
     setConditionItems(items)
-    console.log({ id })
   }
 
   const doSubmit = async (e) => {
     e.preventDefault()
-    console.log({
-      booleanLogic,
-      conditionItems,
+    setIsLoading(true)
+    const client = new LitJsSdk.LitNodeClient({
+      alertWhenUnauthorized: false,
     })
+    await client.connect()
+    const chain = chainItem.id
+    const authSig = await LitJsSdk.checkAndSignAuthMessage({ chain })
+    const allAddressArr = conversations.map((item) => item.peerAddress)
+
+    const allValidateAddress = []
+    const filterResultAddressArr = await Promise.all(
+      conditionItems.map(async (item) => {
+        const { contractAddress, comparator, contractType } = item
+        const verifiedRz = await Promise.all(
+          allAddressArr.map(async (userWalletAddress) => {
+            const accessControlConditions = []
+            switch (contractType) {
+              case 'ETH':
+                accessControlConditions.push({
+                  contractAddress: '',
+                  standardContractType: '',
+                  chain,
+                  method: 'eth_getBalance',
+                  parameters: [userWalletAddress, 'latest'],
+                  returnValueTest: {
+                    comparator,
+                    value: ethers.utils.parseEther(item.number).toString(),
+                  },
+                })
+                break
+              case 'ERC20':
+                accessControlConditions.push({
+                  contractAddress: '',
+                  standardContractType: '',
+                  chain,
+                  method: 'balanceOf',
+                  parameters: [userWalletAddress],
+                  returnValueTest: {
+                    comparator,
+                    value: ethers.utils.parseEther(item.number).toString(),
+                  },
+                })
+                break
+              case 'ERC721':
+                accessControlConditions.push({
+                  contractAddress,
+                  standardContractType: 'ERC721',
+                  chain,
+                  method: 'balanceOf',
+                  parameters: [userWalletAddress],
+                  returnValueTest: {
+                    comparator,
+                    value: item.number,
+                  },
+                })
+                break
+              case 'ERC777':
+                accessControlConditions.push({
+                  contractAddress,
+                  standardContractType: 'ERC777',
+                  chain,
+                  method: 'balanceOf',
+                  parameters: [userWalletAddress],
+                  returnValueTest: {
+                    comparator,
+                    value: item.number,
+                  },
+                })
+                break
+              case 'ERC1155':
+                accessControlConditions.push({
+                  contractAddress,
+                  standardContractType: 'ERC1155',
+                  chain,
+                  method: 'balanceOf',
+                  parameters: [userWalletAddress, item.tokenId],
+                  returnValueTest: {
+                    comparator,
+                    value: item.number,
+                  },
+                })
+                break
+            }
+
+            const randomNumber = Math.floor(Math.random() * 100000)
+            const resourceId = {
+              baseUrl: 'https://chat.xmtp.com',
+              path: `/${contractAddress}/${userWalletAddress}/${Date.now()}/${randomNumber}`,
+              orgId: '',
+              role: '',
+              extraData: '',
+            }
+
+            try {
+              await client.saveSigningCondition({
+                accessControlConditions,
+                chain,
+                authSig,
+                resourceId,
+              })
+              const jwt = await client.getSignedToken({
+                accessControlConditions,
+                chain,
+                authSig,
+                resourceId,
+              })
+
+              const { verified } = LitJsSdk.verifyJwt({ jwt })
+              return [userWalletAddress, verified]
+            } catch (err) {
+              console.log('err', err)
+
+              return [userWalletAddress, false]
+            }
+          })
+        )
+        const validateAddressArr = verifiedRz
+          .filter((item) => item[1] === true)
+          .map((item) => item[0])
+        allValidateAddress.push(validateAddressArr)
+        return {
+          ...item,
+          validateAddressArr,
+        }
+      })
+    )
+    setConditionItems(filterResultAddressArr)
+
+    setIsLoading(false)
   }
+  useEffect(() => {
+    const funcMap = {
+      intersection,
+      union,
+    }
+    const allValidateAddress = conditionItems.map(
+      ({ validateAddressArr }) => validateAddressArr
+    )
+    setAllLitValidateAddress(funcMap[booleanLogic.id](...allValidateAddress))
+  }, [booleanLogic, conditionItems, setAllLitValidateAddress])
+
   return (
     <Transition.Root show={props.open} as={Fragment}>
       <Dialog as="div" className="relative z-10" onClose={props.onClose}>
@@ -88,6 +248,26 @@ export default function ConversationFilterSlideOver(props) {
                       </div>
                       <div className="flex flex-col justify-between flex-1">
                         <div className="px-4 divide-y divide-gray-200 sm:px-6">
+                          <div className="flex items-center justify-end pt-4 pb-6 text-sm">
+                            On which chain:
+                            <div className="w-32 ml-2">
+                              <Selector
+                                items={chainItems}
+                                selected={chainItem}
+                                onSelected={(item) => setChainItem(item)}
+                              ></Selector>
+                            </div>
+                          </div>
+                          <div className="flex items-center justify-end pt-4 pb-6 text-sm">
+                            All the LIT conditions should be:
+                            <div className="w-32 ml-2">
+                              <Selector
+                                items={booleanLogicItems}
+                                selected={booleanLogic}
+                                onSelected={(item) => setBooleanLogic(item)}
+                              ></Selector>
+                            </div>
+                          </div>
                           <div className="pt-6 pb-5 space-y-6">
                             {conditionItems &&
                               conditionItems.map((item, index) => {
@@ -95,6 +275,7 @@ export default function ConversationFilterSlideOver(props) {
                                   <LitACLItem
                                     key={item.id}
                                     id={item.id}
+                                    validateAddressArr={item.validateAddressArr}
                                     contractType={item.contractType}
                                     onUpdate={({ key, value }) => {
                                       conditionItems[index][key] = value
@@ -109,52 +290,42 @@ export default function ConversationFilterSlideOver(props) {
                               <button
                                 type="button"
                                 className="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-green-500 border border-transparent rounded-md shadow-sm hover:bg-green-700 "
-                                onClick={() =>
-                                  setConditionItems([
-                                    ...conditionItems,
-                                    {
-                                      ...defaultConditionItem,
-                                      id:
-                                        Date.now() +
-                                        '' +
-                                        Math.floor(Math.random() * 100000),
-                                    },
-                                  ])
-                                }
+                                onClick={addItem}
                               >
                                 <PlusCircleIcon className="w-5 h-5 mr-1 text-white hover:cursor-pointer" />
-                                Add
+                                Add Condition
                               </button>
-                            </div>
-                          </div>
-                          <div className="flex items-center justify-end pt-4 pb-6 text-sm">
-                            All the LIT conditions should be:
-                            <div className="w-32 ml-2">
-                              <Selector
-                                items={booleanLogicItems}
-                                selected={booleanLogic}
-                                onSelected={(item) => setBooleanLogic(item)}
-                              ></Selector>
                             </div>
                           </div>
                         </div>
                       </div>
                     </div>
-
-                    {JSON.stringify(conditionItems)}
-                    <div className="flex justify-end flex-shrink-0 px-4 py-4">
+                    <div className="flex items-center justify-end flex-shrink-0 px-4 py-4">
+                      <div className="flex items-center justify-end">
+                        <div className="mr-3">
+                          <div>
+                            LIT condition {booleanLogic.id} result
+                            {allLitValidateAddress.map((address) => {
+                              return <div>{address}</div>
+                            })}
+                          </div>
+                        </div>
+                        <button
+                          onClick={(e) => doSubmit(e)}
+                          disabled={isLoading}
+                          className="inline-flex justify-center px-4 py-2 ml-4 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-gray-500"
+                        >
+                          {isLoading ? 'loading...' : 'Calculate with LIT'}
+                        </button>
+                      </div>
+                    </div>
+                    <div className="flex items-center justify-end flex-shrink-0 px-4 py-4">
                       <button
                         type="button"
                         className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
                         onClick={props.onClose}
                       >
-                        Cancel
-                      </button>
-                      <button
-                        onClick={(e) => doSubmit(e)}
-                        className="inline-flex justify-center px-4 py-2 ml-4 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                      >
-                        Save
+                        Close
                       </button>
                     </div>
                   </form>

--- a/components/ConversationFilterSlideOver.tsx
+++ b/components/ConversationFilterSlideOver.tsx
@@ -1,26 +1,30 @@
-import { Fragment, useState } from 'react'
+import { Fragment, useContext } from 'react'
+import CyberConnectContext from '../contexts/cyberConnect'
 import { Dialog, Transition } from '@headlessui/react'
 import { XIcon } from '@heroicons/react/outline'
 import Selector from './Selector'
 import LitACLItem from './LitACLItem'
 import { PlusCircleIcon } from '@heroicons/react/solid'
+import { booleanLogicItems } from '../contexts/cyberConnect'
+
+const defaultConditionItem = {
+  id: '',
+  contractType: 'ERC721',
+  contractAddress: '',
+  comparator: '',
+  number: '',
+}
 
 export default function ConversationFilterSlideOver(props) {
-  const booleanLogicItems = [
-    { id: 'intersection', name: 'intersection' },
-    { id: 'union', name: 'union' },
-  ]
-  const [booleanLogic, setBooleanLogic] = useState(booleanLogicItems[0])
+  const { booleanLogic, conditionItems, setBooleanLogic, setConditionItems } =
+    useContext(CyberConnectContext)
 
-  const defaultConditionItem = {
-    contractType: 'ERC721',
-    contractAddress: '',
-    comparator: '',
-    number: '',
+  const deleteItem = (id) => {
+    const items = conditionItems.filter((item) => item.id !== id)
+    setConditionItems(items)
+    console.log({ id })
   }
-  const [conditionItems, setConditionItems] = useState([
-    { ...defaultConditionItem },
-  ])
+
   const doSubmit = async (e) => {
     e.preventDefault()
     console.log({
@@ -85,31 +89,36 @@ export default function ConversationFilterSlideOver(props) {
                       <div className="flex flex-col justify-between flex-1">
                         <div className="px-4 divide-y divide-gray-200 sm:px-6">
                           <div className="pt-6 pb-5 space-y-6">
-                            {conditionItems.map((item, index) => {
-                              return (
-                                <LitACLItem
-                                  key={index}
-                                  contractType={item.contractType}
-                                  onUpdate={({ key, value }) => {
-                                    conditionItems[index][key] = value
-                                    setConditionItems([...conditionItems])
-                                  }}
-                                  onDelete={() => {
-                                    conditionItems.splice(index, 1)
-                                    setConditionItems([...conditionItems])
-                                  }}
-                                />
-                              )
-                            })}
+                            {conditionItems &&
+                              conditionItems.map((item, index) => {
+                                return (
+                                  <LitACLItem
+                                    key={item.id}
+                                    id={item.id}
+                                    contractType={item.contractType}
+                                    onUpdate={({ key, value }) => {
+                                      conditionItems[index][key] = value
+                                      setConditionItems([...conditionItems])
+                                    }}
+                                    onDelete={deleteItem}
+                                  />
+                                )
+                              })}
 
                             <div className="flex items-center justify-end">
                               <button
                                 type="button"
-                                className="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                                className="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-green-500 border border-transparent rounded-md shadow-sm hover:bg-green-700 "
                                 onClick={() =>
                                   setConditionItems([
                                     ...conditionItems,
-                                    { ...defaultConditionItem },
+                                    {
+                                      ...defaultConditionItem,
+                                      id:
+                                        Date.now() +
+                                        '' +
+                                        Math.floor(Math.random() * 100000),
+                                    },
                                   ])
                                 }
                               >
@@ -131,6 +140,8 @@ export default function ConversationFilterSlideOver(props) {
                         </div>
                       </div>
                     </div>
+
+                    {JSON.stringify(conditionItems)}
                     <div className="flex justify-end flex-shrink-0 px-4 py-4">
                       <button
                         type="button"

--- a/components/ConversationsList.tsx
+++ b/components/ConversationsList.tsx
@@ -115,7 +115,7 @@ const ConversationsList = ({
 
   useEffect(() => {
     setFilteredConversations(filterConversations(conversations))
-  }, [filterBy, conversations])
+  }, [filterBy, conversations, filterConversations])
 
   return (
     <div>

--- a/components/ConversationsList.tsx
+++ b/components/ConversationsList.tsx
@@ -8,7 +8,8 @@ import { XmtpContext } from '../contexts/xmtp'
 import { Message } from '@xmtp/xmtp-js'
 import useWallet from '../hooks/useWallet'
 import Avatar from './Avatar'
-import { useContext } from 'react'
+import { useContext, useEffect, useState } from 'react'
+import CyberConnectContext from '../contexts/cyberConnect'
 
 type ConversationsListProps = {
   conversations: Conversation[]
@@ -95,6 +96,7 @@ const ConversationsList = ({
 }: ConversationsListProps): JSX.Element => {
   const router = useRouter()
   const { getMessages } = useContext(XmtpContext)
+  const { filterBy, filterConversations } = useContext(CyberConnectContext)
   const orderByLatestMessage = (
     convoA: Conversation,
     convoB: Conversation
@@ -107,10 +109,18 @@ const ConversationsList = ({
       getLatestMessage(convoBMessages)?.sent || new Date()
     return convoALastMessageDate < convoBLastMessageDate ? 1 : -1
   }
+
+  const [filterdConversations, setFilteredConversations] =
+    useState<ConversationsListProps>()
+
+  useEffect(() => {
+    setFilteredConversations(filterConversations(conversations))
+  }, [filterBy, conversations])
+
   return (
     <div>
-      {conversations &&
-        conversations.sort(orderByLatestMessage).map((convo) => {
+      {filterdConversations &&
+        filterdConversations.sort(orderByLatestMessage).map((convo) => {
           const isSelected =
             router.query.recipientWalletAddr == convo.peerAddress
           return (

--- a/components/CyberConnectProvider.tsx
+++ b/components/CyberConnectProvider.tsx
@@ -13,7 +13,7 @@ import {
   ApolloProvider,
   useLazyQuery,
 } from '@apollo/client'
-import { Conversations } from '@xmtp/xmtp-js/dist/types/src'
+// import { Conversations } from '@xmtp/xmtp-js/dist/types/src'
 const CYBERCONNECT_ENDPOINT = 'https://api.cybertino.io/connect/'
 
 const client = new ApolloClient({
@@ -72,10 +72,13 @@ export const CyberConnectProvider: React.FC = ({ children }) => {
       if (identity[filterBy]) {
         if (identity[filterBy].list.length === 0) return []
         const list = identity[filterBy].list.map(({ address }) =>
-          ethers.utils.getAddress(address)
+          address.toString().toLowerCase()
         )
+        console.log(list)
+
         return conversations.filter((item) => {
-          return list.includes(item.client.address)
+          const address = item.peerAddress.toString().toLowerCase()
+          return list.includes(address)
         })
       }
 

--- a/components/CyberConnectProvider.tsx
+++ b/components/CyberConnectProvider.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ethers } from 'ethers'
+import useXmtp from '../hooks/useXmtp'
+import {
+  CyberConnectContext,
+  CyberConnectContextType,
+} from '../contexts/cyberConnect'
+import { GET_IDENTITY } from '../gql/GET_IDENTITY'
+
+import {
+  ApolloClient,
+  InMemoryCache,
+  ApolloProvider,
+  useLazyQuery,
+} from '@apollo/client'
+import { Conversations } from '@xmtp/xmtp-js/dist/types/src'
+const CYBERCONNECT_ENDPOINT = 'https://api.cybertino.io/connect/'
+
+const client = new ApolloClient({
+  uri: CYBERCONNECT_ENDPOINT,
+  cache: new InMemoryCache(),
+})
+
+export const CyberConnectProvider: React.FC = ({ children }) => {
+  const [filterBy, setFilterBy] = useState<string>()
+  const [categoryBy, setCategoryBy] = useState<string>()
+  const [identity, setIdentity] = useState<any>()
+  const { walletAddress, conversations } = useXmtp()
+
+  const updateFilterBy = useCallback(
+    (newFilterBy) => {
+      setFilterBy(newFilterBy)
+    },
+    [setFilterBy]
+  )
+
+  const [getIdentity, { loading, error, data }] = useLazyQuery(GET_IDENTITY, {
+    client,
+  })
+
+  useEffect(() => {
+    if (!walletAddress) return
+
+    getIdentity({
+      variables: { address: walletAddress },
+    })
+  }, [walletAddress, getIdentity])
+
+  const updateIdentity = useCallback(
+    (identity) => setIdentity(identity),
+    [setIdentity]
+  )
+
+  useEffect(() => {
+    if (!data) return
+    if (loading) return
+    if (error) {
+      console.error(error)
+      return
+    }
+    updateIdentity(data.identity)
+  }, [loading, error, data, updateIdentity])
+
+  const updateCategoryBy = useCallback(
+    (newCategoryBy) => {
+      setCategoryBy(newCategoryBy)
+    },
+    [setCategoryBy]
+  )
+  const filterConversations = useCallback(
+    (conversations) => {
+      if (identity[filterBy]) {
+        if (identity[filterBy].list.length === 0) return []
+        const list = identity[filterBy].list.map(({ address }) =>
+          ethers.utils.getAddress(address)
+        )
+        return conversations.filter((item) => {
+          return list.includes(item.client.address)
+        })
+      }
+
+      return conversations
+    },
+    [filterBy, identity]
+  )
+  const [providerState, setProviderState] = useState<CyberConnectContextType>({
+    filterBy,
+    categoryBy,
+    identity,
+    updateFilterBy,
+    updateCategoryBy,
+    updateIdentity,
+    filterConversations,
+  })
+
+  useEffect(() => {
+    setProviderState({
+      filterBy,
+      categoryBy,
+      identity,
+      updateFilterBy,
+      updateCategoryBy,
+      updateIdentity,
+      filterConversations,
+    })
+  }, [
+    filterBy,
+    categoryBy,
+    identity,
+    updateFilterBy,
+    updateCategoryBy,
+    updateIdentity,
+    filterConversations,
+  ])
+
+  return (
+    <ApolloProvider client={client}>
+      <CyberConnectContext.Provider value={providerState}>
+        {children}
+      </CyberConnectContext.Provider>
+    </ApolloProvider>
+  )
+}
+
+export default CyberConnectProvider

--- a/components/CyberConnectProvider.tsx
+++ b/components/CyberConnectProvider.tsx
@@ -4,6 +4,9 @@ import useXmtp from '../hooks/useXmtp'
 import {
   CyberConnectContext,
   CyberConnectContextType,
+  BooleanLogic,
+  ConditionItem,
+  booleanLogicItems,
 } from '../contexts/cyberConnect'
 import { GET_IDENTITY } from '../gql/GET_IDENTITY'
 
@@ -22,7 +25,11 @@ const client = new ApolloClient({
 })
 
 export const CyberConnectProvider: React.FC = ({ children }) => {
-  const [filterBy, setFilterBy] = useState<string>()
+  const [filterBy, setFilterBy] = useState<string>('Friends')
+  const [booleanLogic, setBooleanLogic] = useState<BooleanLogic>(
+    booleanLogicItems[0]
+  )
+  const [conditionItems, setConditionItems] = useState<ConditionItem>([])
   const [categoryBy, setCategoryBy] = useState<string>()
   const [identity, setIdentity] = useState<any>()
   const { walletAddress, conversations } = useXmtp()
@@ -88,8 +95,12 @@ export const CyberConnectProvider: React.FC = ({ children }) => {
   )
   const [providerState, setProviderState] = useState<CyberConnectContextType>({
     filterBy,
+    booleanLogic,
+    conditionItems,
     categoryBy,
     identity,
+    setBooleanLogic,
+    setConditionItems,
     updateFilterBy,
     updateCategoryBy,
     updateIdentity,
@@ -99,18 +110,26 @@ export const CyberConnectProvider: React.FC = ({ children }) => {
   useEffect(() => {
     setProviderState({
       filterBy,
+      booleanLogic,
+      conditionItems,
       categoryBy,
       identity,
       updateFilterBy,
+      setBooleanLogic,
+      setConditionItems,
       updateCategoryBy,
       updateIdentity,
       filterConversations,
     })
   }, [
     filterBy,
+    booleanLogic,
+    conditionItems,
     categoryBy,
     identity,
     updateFilterBy,
+    setBooleanLogic,
+    setConditionItems,
     updateCategoryBy,
     updateIdentity,
     filterConversations,

--- a/components/CyberConnectProvider.tsx
+++ b/components/CyberConnectProvider.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useState } from 'react'
 import { ethers } from 'ethers'
+import LitJsSdk from 'lit-js-sdk'
 import useXmtp from '../hooks/useXmtp'
 import {
   CyberConnectContext,
   CyberConnectContextType,
   BooleanLogic,
+  ChainItem,
   ConditionItem,
   booleanLogicItems,
 } from '../contexts/cyberConnect'
@@ -24,15 +26,26 @@ const client = new ApolloClient({
   cache: new InMemoryCache(),
 })
 
+export const chainItems = Object.keys(LitJsSdk.ALL_LIT_CHAINS).map((key) => {
+  return { id: key, name: key }
+})
+
 export const CyberConnectProvider: React.FC = ({ children }) => {
-  const [filterBy, setFilterBy] = useState<string>('Friends')
+  const [filterBy, setFilterBy] = useState<string>('friends')
+  const [allLitValidateAddress, setAllLitValidateAddress] = useState<[string]>(
+    []
+  )
+  const [chainItem, setChainItem] = useState<ChainItem>({
+    id: 'ethereum',
+    name: 'ethereum',
+  })
   const [booleanLogic, setBooleanLogic] = useState<BooleanLogic>(
     booleanLogicItems[0]
   )
   const [conditionItems, setConditionItems] = useState<ConditionItem>([])
   const [categoryBy, setCategoryBy] = useState<string>()
   const [identity, setIdentity] = useState<any>()
-  const { walletAddress, conversations } = useXmtp()
+  const { walletAddress } = useXmtp()
 
   const updateFilterBy = useCallback(
     (newFilterBy) => {
@@ -74,25 +87,7 @@ export const CyberConnectProvider: React.FC = ({ children }) => {
     },
     [setCategoryBy]
   )
-  const filterConversations = useCallback(
-    (conversations) => {
-      if (identity[filterBy]) {
-        if (identity[filterBy].list.length === 0) return []
-        const list = identity[filterBy].list.map(({ address }) =>
-          address.toString().toLowerCase()
-        )
-        console.log(list)
 
-        return conversations.filter((item) => {
-          const address = item.peerAddress.toString().toLowerCase()
-          return list.includes(address)
-        })
-      }
-
-      return conversations
-    },
-    [filterBy, identity]
-  )
   const [providerState, setProviderState] = useState<CyberConnectContextType>({
     filterBy,
     booleanLogic,
@@ -104,7 +99,10 @@ export const CyberConnectProvider: React.FC = ({ children }) => {
     updateFilterBy,
     updateCategoryBy,
     updateIdentity,
-    filterConversations,
+    chainItem,
+    setChainItem,
+    allLitValidateAddress,
+    setAllLitValidateAddress,
   })
 
   useEffect(() => {
@@ -119,7 +117,10 @@ export const CyberConnectProvider: React.FC = ({ children }) => {
       setConditionItems,
       updateCategoryBy,
       updateIdentity,
-      filterConversations,
+      chainItem,
+      setChainItem,
+      allLitValidateAddress,
+      setAllLitValidateAddress,
     })
   }, [
     filterBy,
@@ -132,7 +133,10 @@ export const CyberConnectProvider: React.FC = ({ children }) => {
     setConditionItems,
     updateCategoryBy,
     updateIdentity,
-    filterConversations,
+    chainItem,
+    setChainItem,
+    allLitValidateAddress,
+    setAllLitValidateAddress,
   ])
 
   return (

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -13,24 +13,24 @@ import UserMenu from './UserMenu'
 import BackArrow from './BackArrow'
 
 const NavigationColumnLayout: React.FC = ({ children }) => (
-  <aside className="flex w-full md:w-84 flex-col flex-grow fixed inset-y-0">
-    <div className="flex flex-col flex-grow md:border-r md:border-gray-200 bg-white overflow-y-auto">
+  <aside className="fixed inset-y-0 flex flex-col flex-grow w-full md:w-84">
+    <div className="flex flex-col flex-grow overflow-y-auto bg-white md:border-r md:border-gray-200">
       {children}
     </div>
   </aside>
 )
 
 const NavigationHeaderLayout: React.FC = ({ children }) => (
-  <div className="h-14 bg-p-600 flex items-center justify-between flex-shrink-0 px-4">
+  <div className="flex items-center justify-between flex-shrink-0 px-4 h-14 bg-p-600">
     <Link href="/" passHref={true}>
-      <img className="h-8 w-auto" src="/xmtp-icon.png" alt="XMTP" />
+      <img className="w-auto h-8" src="/xmtp-icon.png" alt="XMTP" />
     </Link>
     {children}
   </div>
 )
 
 const TopBarLayout: React.FC = ({ children }) => (
-  <div className="sticky top-0 z-10 flex-shrink-0 flex bg-zinc-50 border-b border-gray-200 md:bg-white md:border-0">
+  <div className="sticky top-0 z-10 flex flex-shrink-0 border-b border-gray-200 bg-zinc-50 md:bg-white md:border-0">
     {children}
   </div>
 )
@@ -53,7 +53,7 @@ const ConversationLayout: React.FC = ({ children }) => {
   return (
     <>
       <TopBarLayout>
-        <div className="md:hidden flex items-center ml-3">
+        <div className="flex items-center ml-3 md:hidden">
           <BackArrow onClick={handleBackArrowClick} />
         </div>
         <RecipientControl

--- a/components/LitACLItem.tsx
+++ b/components/LitACLItem.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+import Selector from './Selector'
+import { MinusCircleIcon } from '@heroicons/react/solid'
+
+export default function LitACLItem(props) {
+  const contractTypeItems = [
+    { id: 'ETH', name: 'ETH' },
+    { id: 'ERC20', name: 'ERC20' },
+    { id: 'ERC721', name: 'ERC721' },
+    { id: 'ERC777', name: 'ERC777' },
+    { id: 'ERC1155', name: 'ERC1155' },
+  ]
+  const selected = {
+    id: props.contractType,
+    name: props.contractType,
+  }
+
+  return (
+    <div className="flex items-center justify-between">
+      <div className="w-28">
+        <Selector
+          items={contractTypeItems}
+          selected={selected}
+          onSelected={(item) =>
+            props.onUpdate({ key: 'contractType', value: item.id })
+          }
+        ></Selector>
+      </div>
+      <input
+        type="text"
+        value={props.contractAddress}
+        onChange={(e) =>
+          props.onUpdate({ key: 'contractAddress', value: e.target.value })
+        }
+        disabled={props.contractType === 'ETH'}
+        name="contractAddress"
+        placeholder="contract address"
+        className="flex-1 block mx-2 border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm disabled:bg-gray-200 disabled:cursor-not-allowed"
+      />
+      <input
+        type="text"
+        value={props.comparator}
+        name="comparator"
+        onChange={(e) =>
+          props.onUpdate({ key: 'comparator', value: e.target.value })
+        }
+        placeholder="comparator, must be one of <, <=, =, >=, >"
+        className="flex-1 block mx-2 border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+      />
+      <input
+        name="number"
+        type="number"
+        value={props.number}
+        onChange={(e) =>
+          props.onUpdate({ key: 'number', value: e.target.value })
+        }
+        placeholder="number"
+        className="block w-40 mx-2 border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+      />
+      <MinusCircleIcon
+        className="w-6 h-6 text-red-500 hover:cursor-pointer"
+        onClick={() => props.onDelete()}
+      />
+    </div>
+  )
+}

--- a/components/LitACLItem.tsx
+++ b/components/LitACLItem.tsx
@@ -21,9 +21,12 @@ export default function LitACLItem(props) {
         <Selector
           items={contractTypeItems}
           selected={selected}
-          onSelected={(item) =>
+          onSelected={(item) => {
             props.onUpdate({ key: 'contractType', value: item.id })
-          }
+            if (item.id === 'ETH') {
+              props.onUpdate({ key: 'contractAddress', value: '' })
+            }
+          }}
         ></Selector>
       </div>
       <input
@@ -51,6 +54,7 @@ export default function LitACLItem(props) {
         name="number"
         type="number"
         value={props.number}
+        min="0"
         onChange={(e) =>
           props.onUpdate({ key: 'number', value: e.target.value })
         }
@@ -59,7 +63,7 @@ export default function LitACLItem(props) {
       />
       <MinusCircleIcon
         className="w-6 h-6 text-red-500 hover:cursor-pointer"
-        onClick={() => props.onDelete()}
+        onClick={() => props.onDelete(props.id)}
       />
     </div>
   )

--- a/components/LitACLItem.tsx
+++ b/components/LitACLItem.tsx
@@ -15,8 +15,45 @@ export default function LitACLItem(props) {
     name: props.contractType,
   }
 
+  let contractAddressInput = ''
+  if (props.contractType !== 'ETH') {
+    contractAddressInput = (
+      <input
+        type="text"
+        value={props.contractAddress}
+        onChange={(e) =>
+          props.onUpdate({ key: 'contractAddress', value: e.target.value })
+        }
+        name="contractAddress"
+        placeholder="contract address"
+        className="flex-1 block mx-2 border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm disabled:bg-gray-200 disabled:cursor-not-allowed"
+      />
+    )
+  }
+
+  let tokenIdInput = ''
+  if (props.contractType === 'ERC1155') {
+    tokenIdInput = (
+      <input
+        type="text"
+        value={props.tokenId}
+        onChange={(e) =>
+          props.onUpdate({ key: 'tokenId', value: e.target.value })
+        }
+        name="tokenId"
+        placeholder="tokenId"
+        className="flex-1 block mx-2 border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm disabled:bg-gray-200 disabled:cursor-not-allowed"
+      />
+    )
+  }
+
+  let resultCount = ''
+  if (props.validateAddressArr) {
+    resultCount = <div className="px-1">{props.validateAddressArr.length}</div>
+  }
   return (
     <div className="flex items-center justify-between">
+      {resultCount}
       <div className="w-28">
         <Selector
           items={contractTypeItems}
@@ -29,17 +66,8 @@ export default function LitACLItem(props) {
           }}
         ></Selector>
       </div>
-      <input
-        type="text"
-        value={props.contractAddress}
-        onChange={(e) =>
-          props.onUpdate({ key: 'contractAddress', value: e.target.value })
-        }
-        disabled={props.contractType === 'ETH'}
-        name="contractAddress"
-        placeholder="contract address"
-        className="flex-1 block mx-2 border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm disabled:bg-gray-200 disabled:cursor-not-allowed"
-      />
+      {contractAddressInput}
+      {tokenIdInput}
       <input
         type="text"
         value={props.comparator}

--- a/components/NavigationPanel.tsx
+++ b/components/NavigationPanel.tsx
@@ -3,6 +3,9 @@ import { ChatIcon } from '@heroicons/react/outline'
 import { ArrowSmRightIcon } from '@heroicons/react/solid'
 import useXmtp from '../hooks/useXmtp'
 import ConversationsList from './ConversationsList'
+import ConversationFilter from './ConversationFilter'
+import ConversationCategory from './ConversationCategory'
+
 import Loader from './Loader'
 
 type NavigationPanelProps = {
@@ -17,7 +20,7 @@ const NavigationPanel = ({ onConnect }: NavigationPanelProps): JSX.Element => {
   const { walletAddress } = useXmtp()
 
   return (
-    <div className="flex-grow flex flex-col">
+    <div className="flex flex-col flex-grow">
       {walletAddress ? (
         <ConversationsPanel />
       ) : (
@@ -31,16 +34,16 @@ const NavigationPanel = ({ onConnect }: NavigationPanelProps): JSX.Element => {
 
 const NoWalletConnectedMessage: React.FC = ({ children }) => {
   return (
-    <div className="flex flex-col flex-grow justify-center">
+    <div className="flex flex-col justify-center flex-grow">
       <div className="flex flex-col items-center px-4 text-center">
         <LinkIcon
-          className="h-8 w-8 mb-1 stroke-n-200 md:stroke-n-300"
+          className="w-8 h-8 mb-1 stroke-n-200 md:stroke-n-300"
           aria-hidden="true"
         />
-        <p className="text-xl md:text-lg text-n-200 md:text-n-300 font-bold">
+        <p className="text-xl font-bold md:text-lg text-n-200 md:text-n-300">
           No wallet connected
         </p>
-        <p className="text-lx md:text-md text-n-200 font-normal">
+        <p className="font-normal text-lx md:text-md text-n-200">
           Please connect a wallet to begin
         </p>
       </div>
@@ -53,9 +56,9 @@ const ConnectButton = ({ onConnect }: ConnectButtonProps): JSX.Element => {
   return (
     <button
       onClick={onConnect}
-      className="rounded border border-l-300 mx-auto my-4 text-l-300 hover:text-white hover:bg-l-400 hover:border-l-400 hover:fill-white focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-n-100 focus-visible:outline-none active:bg-l-500 active:border-l-500 active:text-l-100 active:ring-0"
+      className="mx-auto my-4 border rounded border-l-300 text-l-300 hover:text-white hover:bg-l-400 hover:border-l-400 hover:fill-white focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-n-100 focus-visible:outline-none active:bg-l-500 active:border-l-500 active:text-l-100 active:ring-0"
     >
-      <div className="flex items-center justify-center text-xs font-semibold px-4 py-1">
+      <div className="flex items-center justify-center px-4 py-1 text-xs font-semibold">
         Connect your wallet
         <ArrowSmRightIcon className="h-4" />
       </div>
@@ -86,6 +89,10 @@ const ConversationsPanel = (): JSX.Element => {
 
   return conversations && conversations.length > 0 ? (
     <nav className="flex-1 pb-4 space-y-1">
+      <div className="flex items-center justify-end p-1 border-b-1 border ">
+        <ConversationFilter />
+      </div>
+      {/* <ConversationCategory /> */}
       <ConversationsList conversations={conversations} />
     </nav>
   ) : (
@@ -95,16 +102,16 @@ const ConversationsPanel = (): JSX.Element => {
 
 const NoConversationsMessage = (): JSX.Element => {
   return (
-    <div className="flex flex-col flex-grow justify-center">
+    <div className="flex flex-col justify-center flex-grow">
       <div className="flex flex-col items-center px-4 text-center">
         <ChatIcon
-          className="h-8 w-8 mb-1 stroke-n-200 md:stroke-n-300"
+          className="w-8 h-8 mb-1 stroke-n-200 md:stroke-n-300"
           aria-hidden="true"
         />
-        <p className="text-xl md:text-lg text-n-200 md:text-n-300 font-bold">
+        <p className="text-xl font-bold md:text-lg text-n-200 md:text-n-300">
           Your message list is empty
         </p>
-        <p className="text-lx md:text-md text-n-200 font-normal">
+        <p className="font-normal text-lx md:text-md text-n-200">
           There are no messages in this wallet
         </p>
       </div>

--- a/components/NavigationPanel.tsx
+++ b/components/NavigationPanel.tsx
@@ -4,7 +4,6 @@ import { ArrowSmRightIcon } from '@heroicons/react/solid'
 import useXmtp from '../hooks/useXmtp'
 import ConversationsList from './ConversationsList'
 import ConversationFilter from './ConversationFilter'
-import ConversationCategory from './ConversationCategory'
 
 import Loader from './Loader'
 
@@ -89,7 +88,7 @@ const ConversationsPanel = (): JSX.Element => {
 
   return conversations && conversations.length > 0 ? (
     <nav className="flex-1 pb-4 space-y-1">
-      <div className="flex items-center justify-end p-1 border-b-1 border ">
+      <div className="flex items-center justify-end p-1 border border-b-1 ">
         <ConversationFilter />
       </div>
       {/* <ConversationCategory /> */}

--- a/components/Selector.tsx
+++ b/components/Selector.tsx
@@ -1,0 +1,74 @@
+import { Fragment, useState } from 'react'
+import { Listbox, Transition } from '@headlessui/react'
+import { CheckIcon, SelectorIcon } from '@heroicons/react/solid'
+import { classNames } from '../helpers'
+
+export default function Selector(props) {
+  return (
+    <Listbox value={props.selected} onChange={props.onSelected}>
+      {({ open }) => (
+        <>
+          <Listbox.Label className="block text-sm font-medium text-gray-700"></Listbox.Label>
+          <div className="relative mt-1">
+            <Listbox.Button className="relative w-full py-2 pl-3 pr-10 text-left bg-white border border-gray-300 rounded-md shadow-sm cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+              <span className="block truncate">{props.selected.name}</span>
+              <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+                <SelectorIcon
+                  className="w-5 h-5 text-gray-400"
+                  aria-hidden="true"
+                />
+              </span>
+            </Listbox.Button>
+
+            <Transition
+              show={open}
+              as={Fragment}
+              leave="transition ease-in duration-100"
+              leaveFrom="opacity-100"
+              leaveTo="opacity-0"
+            >
+              <Listbox.Options className="absolute z-10 w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+                {props.items.map((item) => (
+                  <Listbox.Option
+                    key={item.id}
+                    className={({ active }) =>
+                      classNames(
+                        active ? 'text-white bg-indigo-600' : 'text-gray-900',
+                        'cursor-default select-none relative py-2 pl-3 pr-9'
+                      )
+                    }
+                    value={item}
+                  >
+                    {({ selected, active }) => (
+                      <>
+                        <span
+                          className={classNames(
+                            selected ? 'font-semibold' : 'font-normal',
+                            'block truncate'
+                          )}
+                        >
+                          {item.name}
+                        </span>
+
+                        {selected ? (
+                          <span
+                            className={classNames(
+                              active ? 'text-white' : 'text-indigo-600',
+                              'absolute inset-y-0 right-0 flex items-center pr-4'
+                            )}
+                          >
+                            <CheckIcon className="w-5 h-5" aria-hidden="true" />
+                          </span>
+                        ) : null}
+                      </>
+                    )}
+                  </Listbox.Option>
+                ))}
+              </Listbox.Options>
+            </Transition>
+          </div>
+        </>
+      )}
+    </Listbox>
+  )
+}

--- a/components/Selector.tsx
+++ b/components/Selector.tsx
@@ -11,7 +11,9 @@ export default function Selector(props) {
           <Listbox.Label className="block text-sm font-medium text-gray-700"></Listbox.Label>
           <div className="relative mt-1">
             <Listbox.Button className="relative w-full py-2 pl-3 pr-10 text-left bg-white border border-gray-300 rounded-md shadow-sm cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
-              <span className="block truncate">{props.selected.name}</span>
+              <span className="block truncate">
+                {props.selected && props.selected.name}
+              </span>
               <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
                 <SelectorIcon
                   className="w-5 h-5 text-gray-400"
@@ -28,42 +30,46 @@ export default function Selector(props) {
               leaveTo="opacity-0"
             >
               <Listbox.Options className="absolute z-10 w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
-                {props.items.map((item) => (
-                  <Listbox.Option
-                    key={item.id}
-                    className={({ active }) =>
-                      classNames(
-                        active ? 'text-white bg-indigo-600' : 'text-gray-900',
-                        'cursor-default select-none relative py-2 pl-3 pr-9'
-                      )
-                    }
-                    value={item}
-                  >
-                    {({ selected, active }) => (
-                      <>
-                        <span
-                          className={classNames(
-                            selected ? 'font-semibold' : 'font-normal',
-                            'block truncate'
-                          )}
-                        >
-                          {item.name}
-                        </span>
-
-                        {selected ? (
+                {props.items &&
+                  props.items.map((item) => (
+                    <Listbox.Option
+                      key={item.id}
+                      className={({ active }) =>
+                        classNames(
+                          active ? 'text-white bg-indigo-600' : 'text-gray-900',
+                          'cursor-default select-none relative py-2 pl-3 pr-9'
+                        )
+                      }
+                      value={item}
+                    >
+                      {({ selected, active }) => (
+                        <>
                           <span
                             className={classNames(
-                              active ? 'text-white' : 'text-indigo-600',
-                              'absolute inset-y-0 right-0 flex items-center pr-4'
+                              selected ? 'font-semibold' : 'font-normal',
+                              'block truncate'
                             )}
                           >
-                            <CheckIcon className="w-5 h-5" aria-hidden="true" />
+                            {item.name}
                           </span>
-                        ) : null}
-                      </>
-                    )}
-                  </Listbox.Option>
-                ))}
+
+                          {selected ? (
+                            <span
+                              className={classNames(
+                                active ? 'text-white' : 'text-indigo-600',
+                                'absolute inset-y-0 right-0 flex items-center pr-4'
+                              )}
+                            >
+                              <CheckIcon
+                                className="w-5 h-5"
+                                aria-hidden="true"
+                              />
+                            </span>
+                          ) : null}
+                        </>
+                      )}
+                    </Listbox.Option>
+                  ))}
               </Listbox.Options>
             </Transition>
           </div>

--- a/components/WalletProvider.tsx
+++ b/components/WalletProvider.tsx
@@ -37,6 +37,9 @@ export const WalletProvider = ({
       if (cachedLookupAddress.has(address)) {
         return cachedLookupAddress.get(address)
       }
+      if (provider?.network.name === 'maticmum') {
+        return ''
+      }
       const name = (await provider?.lookupAddress(address)) || undefined
       cachedLookupAddress.set(address, name)
       return name

--- a/components/XmtpProvider.tsx
+++ b/components/XmtpProvider.tsx
@@ -59,6 +59,7 @@ export const XmtpProvider: React.FC = ({ children }) => {
       console.log('Listing conversations')
       setLoadingConversations(true)
       const convos = await client.conversations.list()
+
       convos.forEach((convo: Conversation) => {
         dispatchConversations([convo])
       })

--- a/contexts/cyberConnect.ts
+++ b/contexts/cyberConnect.ts
@@ -4,8 +4,25 @@ type ConversationsListProps = {
   conversations: Conversation[]
 }
 
+export type BooleanLogic = { id: string; name: string }
+
+export type ConditionItem = {
+  id: string
+  contractType: string
+  contractAddress: string
+  comparator: string
+  number: number
+}
+
+export const booleanLogicItems = [
+  { id: 'intersection', name: 'intersection' },
+  { id: 'union', name: 'union' },
+]
+
 export type CyberConnectContextType = {
   filterBy: string | undefined
+  booleanLogic: BooleanLogic | undefined
+  conditionItems: [ConditionItem] | []
   categoryBy: string | undefined
   identity: Object | undefined
   updateFilterBy: (val: string) => void
@@ -16,9 +33,13 @@ export type CyberConnectContextType = {
 
 export const CyberConnectContext = createContext<CyberConnectContextType>({
   filterBy: 'Friends',
+  booleanLogic: 'intersection',
+  conditionItems: [],
   categoryBy: 'All',
   identity: {},
   updateFilterBy: () => undefined,
+  setBooleanLogic: () => undefined,
+  setConditionItems: () => undefined,
   updateCategoryBy: () => undefined,
   updateIdentity: () => undefined,
   filterConversations: () => undefined,

--- a/contexts/cyberConnect.ts
+++ b/contexts/cyberConnect.ts
@@ -1,0 +1,27 @@
+import { createContext } from 'react'
+import { Conversation } from '@xmtp/xmtp-js/dist/types/src/conversations'
+type ConversationsListProps = {
+  conversations: Conversation[]
+}
+
+export type CyberConnectContextType = {
+  filterBy: string | undefined
+  categoryBy: string | undefined
+  identity: Object | undefined
+  updateFilterBy: (val: string) => void
+  updateCategoryBy: (val: string) => void
+  updateIdentity: (val: any) => void
+  filterConversations: (val: string) => ConversationsListProps
+}
+
+export const CyberConnectContext = createContext<CyberConnectContextType>({
+  filterBy: 'Friends',
+  categoryBy: 'All',
+  identity: {},
+  updateFilterBy: () => undefined,
+  updateCategoryBy: () => undefined,
+  updateIdentity: () => undefined,
+  filterConversations: () => undefined,
+})
+
+export default CyberConnectContext

--- a/contexts/cyberConnect.ts
+++ b/contexts/cyberConnect.ts
@@ -5,11 +5,12 @@ type ConversationsListProps = {
 }
 
 export type BooleanLogic = { id: string; name: string }
-
+export type ChainItem = { id: string; name: string }
 export type ConditionItem = {
   id: string
   contractType: string
   contractAddress: string
+  tokenId: string
   comparator: string
   number: number
 }
@@ -22,23 +23,31 @@ export const booleanLogicItems = [
 export type CyberConnectContextType = {
   filterBy: string | undefined
   booleanLogic: BooleanLogic | undefined
+  chainItem: ChainItem | undefined
   conditionItems: [ConditionItem] | []
-  categoryBy: string | undefined
   identity: Object | undefined
+  setBooleanLogic: (val: BooleanLogic) => void
+  setConditionItems: (val: ConditionItem) => void
   updateFilterBy: (val: string) => void
   updateCategoryBy: (val: string) => void
   updateIdentity: (val: any) => void
+  setChainItem: (val: ChainItem) => void
   filterConversations: (val: string) => ConversationsListProps
+  allLitValidateAddress: [string] | []
+  setAllLitValidateAddress: (val: []) => undefined
 }
 
 export const CyberConnectContext = createContext<CyberConnectContextType>({
-  filterBy: 'Friends',
+  filterBy: 'friends',
   booleanLogic: 'intersection',
+  chainItem: { id: 'mumbai', name: 'mumbai' },
   conditionItems: [],
-  categoryBy: 'All',
   identity: {},
+  allLitValidateAddress: [],
+  setAllLitValidateAddress: () => undefined,
   updateFilterBy: () => undefined,
   setBooleanLogic: () => undefined,
+  setChainItem: () => undefined,
   setConditionItems: () => undefined,
   updateCategoryBy: () => undefined,
   updateIdentity: () => undefined,

--- a/gql/GET_IDENTITY.ts
+++ b/gql/GET_IDENTITY.ts
@@ -1,0 +1,76 @@
+import { gql } from '@apollo/client'
+export const GET_IDENTITY = gql`
+  query($address: String!, $first: Int, $after: String) {
+    identity(address: $address) {
+      domain
+      avatar
+      joinTime
+      twitter {
+        handle
+        avatar
+        verified
+        tweetId
+        source
+        followerCount
+      }
+      github {
+        username
+        gistId
+        userId
+      }
+      followingCount
+      followings(first: $first, after: $after) {
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+          hasPreviousPage
+        }
+        list {
+          address
+          domain
+          avatar
+          alias
+          namespace
+          lastModifiedTime
+          verifiable
+        }
+      }
+      followerCount
+      followers(first: $first, after: $after) {
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+          hasPreviousPage
+        }
+        list {
+          address
+          domain
+          avatar
+          alias
+          namespace
+          lastModifiedTime
+          verifiable
+        }
+      }
+      friends(first: $first, after: $after) {
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+          hasPreviousPage
+        }
+        list {
+          address
+          domain
+          avatar
+          alias
+          namespace
+          lastModifiedTime
+          verifiable
+        }
+      }
+    }
+  }
+`

--- a/hooks/useCyberConnect.ts
+++ b/hooks/useCyberConnect.ts
@@ -1,0 +1,17 @@
+import { useContext } from 'react'
+import {
+  CyberConnectContextType,
+  CyberConnectContext,
+} from '../contexts/cyberConnect'
+
+const useCyberConnect = (): CyberConnectContextType => {
+  const context = useContext(CyberConnectContext)
+  if (context === undefined) {
+    throw new Error(
+      'useCyberConnect must be used within an CyberConnectProvider'
+    )
+  }
+  return context
+}
+
+export default useCyberConnect

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ethers": "^5.5.3",
     "graphql": "^16.5.0",
     "imagemin-svgo": "^9.0.0",
+    "lit-share-modal": "^0.1.93",
     "next": "12.0.9",
     "next-optimized-images": "^2.6.2",
     "react": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,13 @@
     "url": "https://github.com/xmtp/example-chat-react/issues"
   },
   "dependencies": {
+    "@apollo/client": "^3.6.5",
+    "@cyberlab/cyberconnect": "^4.4.2",
     "@headlessui/react": "^1.4.3",
     "@heroicons/react": "^1.0.5",
     "@xmtp/xmtp-js": "^3.0.0",
     "ethers": "^5.5.3",
+    "graphql": "^16.5.0",
     "imagemin-svgo": "^9.0.0",
     "next": "12.0.9",
     "next-optimized-images": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "graphql": "^16.5.0",
     "imagemin-svgo": "^9.0.0",
     "lit-share-modal": "^0.1.93",
+    "lodash": "^4.17.21",
     "next": "12.0.9",
     "next-optimized-images": "^2.6.2",
     "react": "17.0.2",


### PR DESCRIPTION
* Gate messages with CyberConnect and LIT
  * User can filter by CyberConnect Social Data: friends, followings, followers
  * User can pick the `all` filter that means all the conversations will show up event they do not include in the CyberConnect Social Data
  * User can add LIT control filter too
    * User can select which chain to query for the conditions below
    * User can add ETH, ERC20, ERC721, ERC777, ERC1155 token filters with contract address, comparators (<,<=, =, >=, >), and number
    * All of conditions can be `Intersection` or `Union`
    * User hit the `Calculate with LIT` button will trigger query with LIT and also show the calculate result for each condition and the final result
    * The calculate result will be `intersection` with the CyberConnect Social Data
* In the messages list, user can click on the avatar to go to the [W3NS](https://web3nft.social/0xC6E58fb4aFFB6aB8A392b7CC23CD3feF74517F6C) home page to check the user's more detail social informations
  * User can follow / unfollow some one on W3NS home page
  * User can check someone's followers / followings (something like Instagram)
  * User can click on the `Chat` button to jump to the XMTP application to chat with the user
