### PR TITLE
fix two children with same key warning

### DIFF
--- a/components/Conversation/MessagesList.tsx
+++ b/components/Conversation/MessagesList.tsx
@@ -95,12 +95,14 @@ const MessagesList = ({
               )
               const dateHasChanged = !isOnSameDay(lastMessageDate, msg.sent)
               lastMessageDate = msg.sent
-              return dateHasChanged
-                ? [
-                    <DateDivider date={msg.sent} key={msg.sent?.toString()} />,
-                    tile,
-                  ]
-                : tile
+              return dateHasChanged ? (
+                <div key={msg.id}>
+                  <DateDivider date={msg.sent} />
+                  {tile}
+                </div>
+              ) : (
+                tile
+              )
             })}
             <div ref={messagesEndRef} />
           </div>

--- a/components/Conversation/MessagesList.tsx
+++ b/components/Conversation/MessagesList.tsx
@@ -96,7 +96,10 @@ const MessagesList = ({
               const dateHasChanged = !isOnSameDay(lastMessageDate, msg.sent)
               lastMessageDate = msg.sent
               return dateHasChanged
-                ? [<DateDivider date={msg.sent} key={msg.id} />, tile]
+                ? [
+                    <DateDivider date={msg.sent} key={msg.sent?.toString()} />,
+                    tile,
+                  ]
                 : tile
             })}
             <div ref={messagesEndRef} />


### PR DESCRIPTION
This spammy console warning is caused by using `msg.id` as the key on message tile elements and date divider elements in the message list. 
The PR changes the key on date dividers to a string of the message timestamp.

```
Warning: Encountered two children with the same key, `25aced87f79f3b92b220372ebd3a04f935fcc8e76bf4a2bbbb3efd0589c9e197`. Keys should be 
unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the 
behavior is unsupported and could change in a future version.
```
<img width="1784" alt="CleanShot 2022-06-24 at 11 17 41@2x" src="https://user-images.githubusercontent.com/510695/175623313-225dd2f4-a8c4-44f4-810a-199e7cda998e.png">


