### PR TITLE
improve perceived conversation load time

### DIFF
--- a/components/Conversation/Conversation.tsx
+++ b/components/Conversation/Conversation.tsx
@@ -1,0 +1,59 @@
+import React, { useCallback, useEffect, useRef } from 'react'
+import useXmtp from '../../hooks/useXmtp'
+import useConversation from '../../hooks/useConversation'
+import { MessagesList, MessageComposer } from './'
+import Loader from '../../components/Loader'
+
+type ConversationProps = {
+  recipientWalletAddr: string
+}
+
+const Conversation = ({
+  recipientWalletAddr,
+}: ConversationProps): JSX.Element => {
+  const { walletAddress, client } = useXmtp()
+  const messagesEndRef = useRef(null)
+  const scrollToMessagesEndRef = useCallback(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(messagesEndRef.current as any)?.scrollIntoView({ behavior: 'smooth' })
+  }, [messagesEndRef])
+
+  const { messages, sendMessage, loading } = useConversation(
+    recipientWalletAddr,
+    scrollToMessagesEndRef
+  )
+
+  useEffect(() => {
+    if (!messages) return
+    const initScroll = () => {
+      scrollToMessagesEndRef()
+    }
+    initScroll()
+  }, [recipientWalletAddr, messages, scrollToMessagesEndRef])
+
+  if (!recipientWalletAddr || !walletAddress || !client) {
+    return <div />
+  }
+  if (loading && !messages?.length) {
+    return (
+      <Loader
+        headingText="Loading messages..."
+        subHeadingText="Please wait a moment"
+        isLoading
+      />
+    )
+  }
+
+  return (
+    <main className="flex flex-col flex-1 bg-white h-screen">
+      <MessagesList
+        messagesEndRef={messagesEndRef}
+        messages={messages}
+        walletAddress={walletAddress}
+      />
+      {walletAddress && <MessageComposer onSend={sendMessage} />}
+    </main>
+  )
+}
+
+export default Conversation

--- a/components/Conversation/Conversation.tsx
+++ b/components/Conversation/Conversation.tsx
@@ -23,13 +23,14 @@ const Conversation = ({
     scrollToMessagesEndRef
   )
 
+  const hasMessages = messages.length > 0
   useEffect(() => {
-    if (!messages) return
+    if (!hasMessages) return
     const initScroll = () => {
       scrollToMessagesEndRef()
     }
     initScroll()
-  }, [recipientWalletAddr, messages, scrollToMessagesEndRef])
+  }, [recipientWalletAddr, hasMessages, scrollToMessagesEndRef])
 
   if (!recipientWalletAddr || !walletAddress || !client) {
     return <div />

--- a/components/Conversation/MessageComposer.tsx
+++ b/components/Conversation/MessageComposer.tsx
@@ -35,14 +35,13 @@ const MessageComposer = ({ onSend }: MessageComposerProps): JSX.Element => {
     <div
       className={classNames(
         'sticky',
-        'bottom-3 md:bottom-2',
-        'z-10',
+        'bottom-0',
+        'pl-4',
+        'pt-2',
         'flex-shrink-0',
         'flex',
-        'h-16',
-        'bg-white',
-
-        messageComposerStyles.container
+        'h-[68px]',
+        'bg-white'
       )}
     >
       <form

--- a/components/Conversation/MessagesList.tsx
+++ b/components/Conversation/MessagesList.tsx
@@ -111,4 +111,4 @@ const MessagesList = ({
     </div>
   )
 }
-export default MessagesList
+export default React.memo(MessagesList)

--- a/components/Conversation/RecipientControl.tsx
+++ b/components/Conversation/RecipientControl.tsx
@@ -105,7 +105,7 @@ const RecipientControl = ({
   }
 
   return (
-    <div className="flex-1 flex-col flex h-14 bg-zinc-50 md:border md:border-gray-200 md:rounded-lg md:px-4 md:mx-4 md:mt-4 md:pb-1">
+    <div className="flex-1 flex-col flex h-14 bg-zinc-50 md:border md:border-gray-200 md:rounded-lg md:px-4 md:mx-4 md:mt-4 md:pb-1 md:mb-2">
       <form
         className="w-full flex pl-2 md:pl-0 h-full pt-1"
         action="#"

--- a/components/Conversation/index.ts
+++ b/components/Conversation/index.ts
@@ -1,3 +1,4 @@
 export { default as RecipientControl } from './RecipientControl'
 export { default as MessagesList } from './MessagesList'
 export { default as MessageComposer } from './MessageComposer'
+export { default as Conversation } from './Conversation'

--- a/components/Views/ConversationView.tsx
+++ b/components/Views/ConversationView.tsx
@@ -31,7 +31,7 @@ const ConversationView = ({ children }: ConversationViewProps): JSX.Element => {
       </Transition.Root>
 
       {/* Always show in desktop layout */}
-      <div className="hidden md:bg-white md:pl-84 md:flex md:flex-col md:flex-1 md:h-screen">
+      <div className="hidden md:bg-white md:pl-84 md:flex md:flex-col md:flex-1 md:h-screen md:overflow-y-auto">
         {children}
       </div>
     </>

--- a/pages/dm/[recipientWalletAddr].tsx
+++ b/pages/dm/[recipientWalletAddr].tsx
@@ -1,49 +1,11 @@
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
-import { useCallback, useRef } from 'react'
-import useXmtp from '../../hooks/useXmtp'
-import useConversation from '../../hooks/useConversation'
-import { MessagesList, MessageComposer } from '../../components/Conversation'
-import Loader from '../../components/Loader'
+import { Conversation } from '../../components/Conversation'
 
-const Conversation: NextPage = () => {
+const ConversationPage: NextPage = () => {
   const router = useRouter()
   const recipientWalletAddr = router.query.recipientWalletAddr as string
-  const { walletAddress, client } = useXmtp()
-  const messagesEndRef = useRef(null)
-  const scrollToMessagesEndRef = useCallback(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(messagesEndRef.current as any)?.scrollIntoView({ behavior: 'smooth' })
-  }, [messagesEndRef])
-
-  const { messages, sendMessage, loading } = useConversation(
-    recipientWalletAddr,
-    scrollToMessagesEndRef
-  )
-
-  if (!recipientWalletAddr || !walletAddress || !client) {
-    return <div />
-  }
-  if (loading && !messages?.length) {
-    return (
-      <Loader
-        headingText="Loading messages..."
-        subHeadingText="Please wait a moment"
-        isLoading
-      />
-    )
-  }
-
-  return (
-    <main className="flex flex-col flex-1 bg-white h-screen">
-      <MessagesList
-        messagesEndRef={messagesEndRef}
-        messages={messages}
-        walletAddress={walletAddress}
-      />
-      {walletAddress && <MessageComposer onSend={sendMessage} />}
-    </main>
-  )
+  return <Conversation recipientWalletAddr={recipientWalletAddr} />
 }
 
-export default Conversation
+export default ConversationPage

--- a/styles/MessageComposer.module.scss
+++ b/styles/MessageComposer.module.scss
@@ -1,7 +1,3 @@
-.container {
-  padding: 10px 0 10px 16px;
-}
-
 .bubble {
   border-radius: 24px;
   background-color: #fafafa;


### PR DESCRIPTION
This PR addresses #69 by scrolling immediately after messages are rendered from the local message store, rather than waiting until messages are done being fetched from the network. The latter scroll will also occur in case any new messages are fetched after the initial scroll.

It also memoizes the messages list, which was being re-rendered several times over and slowing down my browser with 100+ messages in my test conversation.

I also slipped in some minor CSS changes to address #68.

This is a significant improvement to the perceived loading speed and rendering of conversations longer than a few messages.

## Conversation with 100+ Messages

### Before
~12 seconds to scroll
![CleanShot 2022-06-26 at 15 25 07](https://user-images.githubusercontent.com/510695/175836123-e34cb49a-8f84-490d-a5f8-d7fe7cf02de4.gif)

### After
<1 seconds to scroll
![CleanShot 2022-06-26 at 15 26 22](https://user-images.githubusercontent.com/510695/175836125-44e3f302-58fa-435b-ba97-7665803d3160.gif)

