### PR TITLE
update recipient control styles

### DIFF
--- a/components/AddressInput.tsx
+++ b/components/AddressInput.tsx
@@ -57,7 +57,7 @@ const AddressInput = ({
 
   const recipientPillInputStyle = classNames(
     'absolute',
-    'top-[4px] md:top-[3px]',
+    'top-[4px] md:top-[2px]',
     'left-[26px] md:left-[23px]',
     'rounded-2xl',
     'px-[5px] md:px-2',

--- a/components/Conversation/RecipientControl.tsx
+++ b/components/Conversation/RecipientControl.tsx
@@ -105,9 +105,9 @@ const RecipientControl = ({
   }
 
   return (
-    <div className="flex-1 flex-col flex h-14 bg-zinc-50 md:border md:border-gray-200 md:rounded-lg md:px-4 md:mx-4 md:mt-4 md:pb-1 md:mb-2">
+    <div className="flex-1 flex-col shrink justify-center flex h-[72px] bg-zinc-50 md:border-b md:border-gray-200 md:px-4 md:pb-[2px]">
       <form
-        className="w-full flex pl-2 md:pl-0 h-full pt-1"
+        className="w-full flex pl-2 md:pl-0 h-8 pt-1"
         action="#"
         method="GET"
         onSubmit={handleSubmit}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -21,7 +21,7 @@ const NavigationColumnLayout: React.FC = ({ children }) => (
 )
 
 const NavigationHeaderLayout: React.FC = ({ children }) => (
-  <div className="h-14 bg-p-600 flex items-center justify-between flex-shrink-0 px-4">
+  <div className="h-[72px] bg-p-600 flex items-center justify-between flex-shrink-0 px-4">
     <Link href="/" passHref={true}>
       <img className="h-8 w-auto" src="/xmtp-icon.png" alt="XMTP" />
     </Link>


### PR DESCRIPTION
Per conversation with @darickdang, the recipient control bar should be affixed to the top rather than floating. The header should also be a bit taller.

Also includes some pixel pushing to better match designs.

### Before
Overflowing messages look sloppy under the floating bar
<img width="442" alt="CleanShot 2022-06-25 at 18 21 41@2x" src="https://user-images.githubusercontent.com/510695/176013751-413bb61c-5703-4668-92c1-83a6edfe94b5.png">

### After
Messages overflow nicely under the fixed bar
<img width="415" alt="CleanShot 2022-06-27 at 11 49 29@2x" src="https://user-images.githubusercontent.com/510695/176014046-f04b354c-b9fe-4488-9fc5-e484c0a2ad8a.png">

