### PR TITLE
Disable ENS lookups on non-Ethereum Chains

### DIFF
--- a/components/WalletProvider.tsx
+++ b/components/WalletProvider.tsx
@@ -99,7 +99,6 @@ export const WalletProvider = ({
   const connect = useCallback(async () => {
     if (!web3Modal) throw new Error('web3Modal not initialized')
     try {
-      console.log('connecting')
       const instance = await web3Modal.connect()
       if (!instance) return
       instance.on('accountsChanged', handleAccountsChanged)
@@ -190,6 +189,7 @@ export const WalletProvider = ({
         signer,
         address,
         web3Modal,
+        chainId,
         resolveName,
         lookupAddress,
         getAvatarUrl,

--- a/components/WalletProvider.tsx
+++ b/components/WalletProvider.tsx
@@ -5,6 +5,8 @@ import WalletConnectProvider from '@walletconnect/web3-provider'
 import WalletLink from 'walletlink'
 import { WalletContext } from '../contexts/wallet'
 
+const ETH_CHAIN_ID = 1 // Ethereum mainnet
+
 const cachedLookupAddress = new Map<string, string | undefined>()
 const cachedResolveName = new Map<string, string | undefined>()
 const cachedGetAvatarUrl = new Map<string, string | undefined>()
@@ -38,6 +40,16 @@ export const WalletProvider = ({
       if (cachedLookupAddress.has(address)) {
         return cachedLookupAddress.get(address)
       }
+      if (provider) {
+        const { chainId } = await provider.getNetwork()
+        if (chainId !== ETH_CHAIN_ID) {
+          console.log(
+            'ENS lookups only available when connected to the Ethereum network'
+          )
+          return undefined
+        }
+      }
+
       const name = (await provider?.lookupAddress(address)) || undefined
       cachedLookupAddress.set(address, name)
       return name

--- a/components/WalletProvider.tsx
+++ b/components/WalletProvider.tsx
@@ -22,17 +22,21 @@ export const WalletProvider = ({
   const [signer, setSigner] = useState<Signer>()
   const [web3Modal, setWeb3Modal] = useState<Web3Modal>()
   const [address, setAddress] = useState<string>()
+  const [chainId, setChainId] = useState<number>()
 
   const resolveName = useCallback(
     async (name: string) => {
       if (cachedResolveName.has(name)) {
         return cachedResolveName.get(name)
       }
+      if (chainId !== ETH_CHAIN_ID) {
+        return undefined
+      }
       const address = (await provider?.resolveName(name)) || undefined
       cachedResolveName.set(name, address)
       return address
     },
-    [provider]
+    [chainId, provider]
   )
 
   const lookupAddress = useCallback(
@@ -40,21 +44,15 @@ export const WalletProvider = ({
       if (cachedLookupAddress.has(address)) {
         return cachedLookupAddress.get(address)
       }
-      if (provider) {
-        const { chainId } = await provider.getNetwork()
-        if (chainId !== ETH_CHAIN_ID) {
-          console.log(
-            'ENS lookups only available when connected to the Ethereum network'
-          )
-          return undefined
-        }
+      if (chainId !== ETH_CHAIN_ID) {
+        return undefined
       }
 
       const name = (await provider?.lookupAddress(address)) || undefined
       cachedLookupAddress.set(address, name)
       return name
     },
-    [provider]
+    [chainId, provider]
   )
 
   const getAvatarUrl = useCallback(
@@ -90,14 +88,26 @@ export const WalletProvider = ({
     [address, disconnect]
   )
 
+  const handleChainChanged = useCallback(
+    ({ chainId }) => {
+      console.log('Chain changed to', chainId)
+      setChainId(chainId)
+    },
+    [setChainId]
+  )
+
   const connect = useCallback(async () => {
     if (!web3Modal) throw new Error('web3Modal not initialized')
     try {
+      console.log('connecting')
       const instance = await web3Modal.connect()
       if (!instance) return
       instance.on('accountsChanged', handleAccountsChanged)
-      const provider = new ethers.providers.Web3Provider(instance)
+      const provider = new ethers.providers.Web3Provider(instance, 'any')
+      provider.on('network', handleChainChanged)
       const signer = provider.getSigner()
+      const { chainId } = await provider.getNetwork()
+      setChainId(chainId)
       setSigner(signer)
       setAddress(await signer.getAddress())
       return signer
@@ -107,7 +117,7 @@ export const WalletProvider = ({
       // modal, as "User closed modal"
       console.log('error', e)
     }
-  }, [web3Modal, handleAccountsChanged])
+  }, [web3Modal, handleAccountsChanged, handleChainChanged])
 
   useEffect(() => {
     const infuraId =
@@ -161,14 +171,17 @@ export const WalletProvider = ({
       const instance = await web3Modal.connectTo(cachedProviderName)
       if (!instance) return
       instance.on('accountsChanged', handleAccountsChanged)
-      const provider = new ethers.providers.Web3Provider(instance)
+      const provider = new ethers.providers.Web3Provider(instance, 'any')
+      provider.on('network', handleChainChanged)
       const signer = provider.getSigner()
+      const { chainId } = await provider.getNetwork()
+      setChainId(chainId)
       setProvider(provider)
       setSigner(signer)
       setAddress(await signer.getAddress())
     }
     initCached()
-  }, [web3Modal, handleAccountsChanged])
+  }, [web3Modal, handleAccountsChanged, handleChainChanged])
 
   return (
     <WalletContext.Provider

--- a/contexts/wallet.ts
+++ b/contexts/wallet.ts
@@ -6,6 +6,7 @@ export type WalletContextType = {
   provider: ethers.providers.Web3Provider | undefined
   signer: Signer | undefined
   address: string | undefined
+  chainId: number | undefined
   web3Modal: Web3Modal | undefined
   resolveName: (name: string) => Promise<string | undefined>
   lookupAddress: (address: string) => Promise<string | undefined>
@@ -19,6 +20,7 @@ export const WalletContext = createContext<WalletContextType>({
   signer: undefined,
   address: undefined,
   web3Modal: undefined,
+  chainId: undefined,
   resolveName: async () => undefined,
   lookupAddress: async () => undefined,
   getAvatarUrl: async () => undefined,


### PR DESCRIPTION
## Summary

The app currently throws errors when attempting to look up ENS information when the user's wallet is connected to a non-ethereum chain.

This change disables ENS lookups when the chain is not ETH mainnet. It also detects chain changes to re-enable ENS lookups when the network is switched back to ETH mainnet.

## Followups
- We should really display a warning when a user attempts to enter an ENS address and their wallet is set to a non-ethereum chain. That can be handled as a subsequent PR.
