### PR TITLE
Update to match template of `xmtp-dot-org` repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a bug report
-title: ''
+title: 'Bug: '
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,29 +7,44 @@ assignees: ''
 
 ---
 
-**Summary**
+## Describe the bug
+
 A clear and concise description of what the bug is.
 
-**Steps to reproduce**
-Steps someone else can follow to reproduce the behavior.
-1. ...
-2. ...
-3. ...
+Include **1 bug per issue**.  Please do not include multiple bugs or pieces of feedback in 1 issue. Creating 1 issue per bug will make it easier for us to assign and track progress on bugs.
 
-**Expected behavior**
+## Steps to Reproduce
+
+Steps to reproduce the behavior:
+
+1. Go to '...' (include a link, if helpful)
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+
 A clear and concise description of what you expected to happen.
 
-**Actual behavior**
-A clear and concise description of what happened instead.
+## Screenshots
 
-**Attachments**
-If applicable, add screenshots or videos to help explain your problem.
+If applicable, add screenshots to help explain your problem.
 
-**Environment**
- - OS version:
- - Browser version:
- - `xmtp-js` version (if known):
- - Deployment URL (if applicable):
+## Additional context
 
-**Additional context**
 Add any other context about the problem here.
+
+### Desktop
+
+Please complete the following information if you think it is relevant to the bug:
+
+- OS & Version: [e.g. macOS 12.3]
+- Browser & Version: [e.g. Chrome 105.0.5195.102, Safari 15.4]
+
+### Smartphone
+
+Please complete the following information if you think it is relevant to the bug:
+
+- Device: [e.g. iPhone 14]
+- OS: [e.g. iOS 16.1]
+- Browser: [e.g. Safari, Chrome]


### PR DESCRIPTION
See here for other example: https://github.com/xmtp/xmtp-dot-org/issues/new?assignees=&labels=bug&template=bug_report.md&title=Bug:+

This update to the bug template cleans things up and makes scanning issues a bit nicer.