### PR TITLE
update to v7.0.1 and report appVersion

### DIFF
--- a/components/Conversation/MessagesList.tsx
+++ b/components/Conversation/MessagesList.tsx
@@ -1,4 +1,4 @@
-import { Message } from '@xmtp/xmtp-js'
+import { DecodedMessage } from '@xmtp/xmtp-js'
 import React, { MutableRefObject } from 'react'
 import Emoji from 'react-emoji-render'
 import Avatar from '../Avatar'
@@ -6,12 +6,12 @@ import { formatTime } from '../../helpers'
 import AddressPill from '../AddressPill'
 
 export type MessageListProps = {
-  messages: Message[]
+  messages: DecodedMessage[]
   messagesEndRef: MutableRefObject<null>
 }
 
 type MessageTileProps = {
-  message: Message
+  message: DecodedMessage
 }
 
 const isOnSameDay = (d1?: Date, d2?: Date): boolean => {
@@ -82,7 +82,7 @@ const MessagesList = ({
             {messages && messages.length ? (
               <ConversationBeginningNotice />
             ) : null}
-            {messages?.map((msg: Message) => {
+            {messages?.map((msg: DecodedMessage) => {
               const dateHasChanged = !isOnSameDay(lastMessageDate, msg.sent)
               lastMessageDate = msg.sent
               return (

--- a/components/ConversationsList.tsx
+++ b/components/ConversationsList.tsx
@@ -4,7 +4,7 @@ import { ChatIcon } from '@heroicons/react/outline'
 import Address from './Address'
 import { useRouter } from 'next/router'
 import { Conversation } from '@xmtp/xmtp-js'
-import { Message } from '@xmtp/xmtp-js'
+import { DecodedMessage } from '@xmtp/xmtp-js'
 import {
   classNames,
   truncate,
@@ -22,7 +22,7 @@ type ConversationTileProps = {
   onClick?: () => void
 }
 
-const getLatestMessage = (messages: Message[]): Message | null =>
+const getLatestMessage = (messages: DecodedMessage[]): DecodedMessage | null =>
   messages?.length ? messages[messages.length - 1] : null
 
 const ConversationTile = ({

--- a/contexts/xmtp.ts
+++ b/contexts/xmtp.ts
@@ -1,11 +1,11 @@
 import { createContext } from 'react'
-import { Client, Message } from '@xmtp/xmtp-js'
+import { Client, DecodedMessage } from '@xmtp/xmtp-js'
 import { Conversation } from '@xmtp/xmtp-js'
 import { Signer } from 'ethers'
 
 export type MessageStoreEvent = {
   peerAddress: string
-  messages: Message[]
+  messages: DecodedMessage[]
 }
 
 export type XmtpContextType = {
@@ -13,8 +13,8 @@ export type XmtpContextType = {
   conversations: Map<string, Conversation> | null
   loadingConversations: boolean
   initClient: (wallet: Signer) => void
-  convoMessages: Map<string, Message[]>
-  setConvoMessages: (value: Map<string, Message[]>) => void
+  convoMessages: Map<string, DecodedMessage[]>
+  setConvoMessages: (value: Map<string, DecodedMessage[]>) => void
 }
 
 export const XmtpContext = createContext<XmtpContextType>({

--- a/helpers/appVersion.ts
+++ b/helpers/appVersion.ts
@@ -1,0 +1,6 @@
+import packageJson from '../package.json'
+
+export const getAppVersion = () => {
+  const { name, version } = packageJson
+  return name + '/' + version
+}

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -1,3 +1,4 @@
 export { default as classNames } from './classNames'
 export * from './string'
 export * from './env'
+export * from './appVersion'

--- a/hooks/useConversation.ts
+++ b/hooks/useConversation.ts
@@ -1,4 +1,4 @@
-import { Conversation, Message, Stream } from '@xmtp/xmtp-js'
+import { Conversation, DecodedMessage, Stream } from '@xmtp/xmtp-js'
 import { useState, useEffect, useContext } from 'react'
 import { WalletContext } from '../contexts/wallet'
 import XmtpContext from '../contexts/xmtp'
@@ -6,7 +6,7 @@ import { checkIfPathIsEns, shortAddress, truncate } from '../helpers'
 
 type OnMessageCallback = () => void
 
-let stream: Stream<Message>
+let stream: Stream<DecodedMessage>
 let latestMsgId: string
 
 const useConversation = (

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@headlessui/react": "^1.4.3",
         "@heroicons/react": "^1.0.5",
-        "@xmtp/xmtp-js": "^6.8.3",
+        "@xmtp/xmtp-js": "^7.0.1",
         "ethers": "^5.5.3",
         "imagemin-svgo": "^9.0.0",
         "next": "12.0.9",
@@ -3713,16 +3713,15 @@
       }
     },
     "node_modules/@xmtp/xmtp-js": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-6.8.3.tgz",
-      "integrity": "sha512-Yc3CZXKozMWg+7280UyPZAuFE7aW/8IB4XJRRqB8d4EYp0Q9GC2dp8Gwl6IFJ/2K9BL0De9/P6dnreRoX1Iydg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-7.0.1.tgz",
+      "integrity": "sha512-mSAUIZOfO/EI4Jy1aWhW+U6YcHKUWvCbs6jl2QD1RioMCcYIAbYK3iM1EG7VRQwRt4BZQTf/FZvqoGVDoX4ucg==",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.2.0",
+        "@xmtp/proto": "^3.4.0",
         "ethers": "^5.5.3",
-        "long": "^5.2.0",
-        "node-localstorage": "^2.2.1"
+        "long": "^5.2.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -12501,6 +12500,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-2.2.1.tgz",
       "integrity": "sha512-vv8fJuOUCCvSPjDjBLlMqYMHob4aGjkmrkaE42/mZr0VT+ZAU10jRF8oTnX9+pgU9/vYJ8P7YT3Vd6ajkmzSCw==",
+      "dev": true,
       "dependencies": {
         "write-file-atomic": "^1.1.4"
       },
@@ -12512,6 +12512,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
       "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -14404,6 +14405,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -19795,16 +19797,15 @@
       }
     },
     "@xmtp/xmtp-js": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-6.8.3.tgz",
-      "integrity": "sha512-Yc3CZXKozMWg+7280UyPZAuFE7aW/8IB4XJRRqB8d4EYp0Q9GC2dp8Gwl6IFJ/2K9BL0De9/P6dnreRoX1Iydg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-7.0.1.tgz",
+      "integrity": "sha512-mSAUIZOfO/EI4Jy1aWhW+U6YcHKUWvCbs6jl2QD1RioMCcYIAbYK3iM1EG7VRQwRt4BZQTf/FZvqoGVDoX4ucg==",
       "requires": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.2.0",
+        "@xmtp/proto": "^3.4.0",
         "ethers": "^5.5.3",
-        "long": "^5.2.0",
-        "node-localstorage": "^2.2.1"
+        "long": "^5.2.0"
       }
     },
     "@xtuc/ieee754": {
@@ -26835,6 +26836,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-2.2.1.tgz",
       "integrity": "sha512-vv8fJuOUCCvSPjDjBLlMqYMHob4aGjkmrkaE42/mZr0VT+ZAU10jRF8oTnX9+pgU9/vYJ8P7YT3Vd6ajkmzSCw==",
+      "dev": true,
       "requires": {
         "write-file-atomic": "^1.1.4"
       },
@@ -26843,6 +26845,7 @@
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
@@ -28286,7 +28289,8 @@
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@headlessui/react": "^1.4.3",
     "@heroicons/react": "^1.0.5",
-    "@xmtp/xmtp-js": "^6.8.3",
+    "@xmtp/xmtp-js": "^7.0.1",
     "ethers": "^5.5.3",
     "imagemin-svgo": "^9.0.0",
     "next": "12.0.9",


### PR DESCRIPTION
## Update to v7.0.1 so we can begin reporting appVersion

- Replaces `Message` with `DecodedMessage`
- Filters out conversations that have `conversationId` to preserve `v6` conversation list
  - from `list`
  - from `stream`

## Report appVersion

- Adds `appVersion: name / version` to client config