### PR TITLE
fix: make blockies match metamask

### DIFF
--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -26,7 +26,7 @@ const Avatar = ({ peerAddress }: AvatarProps) => {
       </div>
     )
   }
-  return <Blockies seed={peerAddress} size={10} className="rounded-full" />
+  return <Blockies seed={peerAddress.toLowerCase()} scale={5} size={8} className="rounded-full" />
 }
 
 export default Avatar

--- a/components/UserMenu.tsx
+++ b/components/UserMenu.tsx
@@ -38,7 +38,7 @@ const AvatarBlock = ({ walletAddress }: AvatarBlockProps) => {
       />
     </div>
   ) : (
-    <Blockies seed={walletAddress} size={8} className="rounded-full mr-2" />
+    <Blockies seed={walletAddress.toLowerCase()} scale={4} size={8} className="rounded-full mr-2" />
   )
 }
 


### PR DESCRIPTION
This makes the example app blockies look like elsewhere (etherscan, metamask etc).

Two fixes: 
- lowercase the address (the char codes are the seed to the random colors so it has to be precise) 
- set the `size` to 8 (that's the number of tiles across) and use `scale` to make it bigger/smaller

<img width="1140" alt="Screen Shot 2022-12-14 at 8 37 21 PM" src="https://user-images.githubusercontent.com/599974/207763980-9e6f4c34-8827-4924-866f-0386e9f07aa5.png">

refs: 
- [metamask lowercasing the address](https://github.com/MetaMask/metamask-extension/blob/develop/ui/components/ui/identicon/blockieIdenticon/blockieIdenticon.component.js#L11)
- [blockies default size = 8](https://github.com/download13/blockies/blob/master/src/blockies.mjs#L69)

fixes [#43]