### PR TITLE
Handle cb.id

### DIFF
--- a/components/AddressInput.tsx
+++ b/components/AddressInput.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react'
-import { checkIfPathIsEns, classNames } from '../helpers'
+import { isEns, classNames, is0xAddress } from '../helpers'
 import useWalletProvider from '../hooks/useWalletProvider'
 import { useAppStore } from '../store/app'
 
@@ -45,7 +45,7 @@ const AddressInput = ({
       if (!lookupAddress) {
         return
       }
-      if (recipientWalletAddress && !checkIfPathIsEns(recipientWalletAddress)) {
+      if (recipientWalletAddress && !isEns(recipientWalletAddress)) {
         const name = await lookupAddress(recipientWalletAddress)
         const conversation = await client?.conversations.newConversation(
           recipientWalletAddress
@@ -59,7 +59,7 @@ const AddressInput = ({
         } else if (recipientWalletAddress) {
           setValue(recipientWalletAddress)
         }
-      } else if (value.startsWith('0x') && value.length === 42) {
+      } else if (is0xAddress(value)) {
         const conversation = await client?.conversations.newConversation(value)
         if (conversation) {
           conversations.set(value, conversation)

--- a/components/Conversation/RecipientControl.tsx
+++ b/components/Conversation/RecipientControl.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/router'
 import AddressInput from '../AddressInput'
-import { checkIfPathIsEns, getAddressFromPath } from '../../helpers'
+import { isEns, getAddressFromPath, is0xAddress } from '../../helpers'
 import { useAppStore } from '../../store/app'
 import useWalletProvider from '../../hooks/useWalletProvider'
 import BackArrow from '../BackArrow'
@@ -54,7 +54,7 @@ const RecipientControl = (): JSX.Element => {
       const name = await lookupAddress(address)
       setHasName(!!name)
     }
-    if (recipientWalletAddress && !checkIfPathIsEns(recipientWalletAddress)) {
+    if (recipientWalletAddress && !isEns(recipientWalletAddress)) {
       setRecipientInputMode(RecipientInputMode.Submitted)
       handleAddressLookup(recipientWalletAddress)
     } else {
@@ -70,7 +70,7 @@ const RecipientControl = (): JSX.Element => {
       }
       const input = e.target as HTMLInputElement
       const recipientValue = value || data.recipient.value
-      if (recipientValue.endsWith('eth')) {
+      if (isEns(recipientValue)) {
         setRecipientInputMode(RecipientInputMode.FindingEntry)
         const address = await resolveName(recipientValue)
         if (address) {
@@ -78,10 +78,7 @@ const RecipientControl = (): JSX.Element => {
         } else {
           setRecipientInputMode(RecipientInputMode.InvalidEntry)
         }
-      } else if (
-        recipientValue.startsWith('0x') &&
-        recipientValue.length === 42
-      ) {
+      } else if (is0xAddress(recipientValue)) {
         await completeSubmit(recipientValue, input)
       }
     },
@@ -96,10 +93,7 @@ const RecipientControl = (): JSX.Element => {
       if (router.pathname !== '/dm') {
         router.push('/dm')
       }
-      if (
-        data.value.endsWith('.eth') ||
-        (data.value.startsWith('0x') && data.value.length === 42)
-      ) {
+      if (isEns(data.value) || is0xAddress(data.value)) {
         handleSubmit(e, data.value)
       } else {
         setRecipientInputMode(RecipientInputMode.InvalidEntry)

--- a/helpers/string.ts
+++ b/helpers/string.ts
@@ -30,9 +30,12 @@ export const checkPath = () => {
   return window.location.pathname !== '/' && window.location.pathname !== '/dm'
 }
 
-export const checkIfPathIsEns = (address: string): boolean => {
-  return address.includes('eth')
+export const isEns = (address: string): boolean => {
+  return address.endsWith('eth') || address.endsWith('.cb.id')
 }
+
+export const is0xAddress = (address: string): boolean =>
+  address.startsWith('0x') && address.length === 42
 
 export const shortAddress = (addr: string): string =>
   addr.length > 10 && addr.startsWith('0x')

--- a/hooks/useEns.ts
+++ b/hooks/useEns.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { isEns } from '../helpers/string'
 import useWalletProvider from './useWalletProvider'
 
 const useEns = (addressOrName: string | undefined) => {
@@ -11,9 +12,7 @@ const useEns = (addressOrName: string | undefined) => {
     addressOrName?.startsWith('0x') && addressOrName?.length === 42
       ? addressOrName
       : undefined
-  const probableName = addressOrName?.endsWith('.eth')
-    ? addressOrName
-    : undefined
+  const probableName = isEns(addressOrName) ? addressOrName : undefined
 
   useEffect(() => {
     if (!resolveName || !lookupAddress || !getAvatarUrl) {

--- a/hooks/useEns.ts
+++ b/hooks/useEns.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { isEns } from '../helpers/string'
+import { is0xAddress, isEns } from '../helpers/string'
 import useWalletProvider from './useWalletProvider'
 
 const useEns = (addressOrName: string | undefined) => {
@@ -9,10 +9,9 @@ const useEns = (addressOrName: string | undefined) => {
   const [avatarUrl, setAvatarUrl] = useState<string>('')
   const [loading, setLoading] = useState<boolean>(true)
   const probableAddress =
-    addressOrName?.startsWith('0x') && addressOrName?.length === 42
-      ? addressOrName
-      : undefined
-  const probableName = isEns(addressOrName) ? addressOrName : undefined
+    addressOrName && is0xAddress(addressOrName) ? addressOrName : undefined
+  const probableName =
+    addressOrName && isEns(addressOrName) ? addressOrName : undefined
 
   useEffect(() => {
     if (!resolveName || !lookupAddress || !getAvatarUrl) {

--- a/pages/dm/[...recipientWalletAddr].tsx
+++ b/pages/dm/[...recipientWalletAddr].tsx
@@ -3,6 +3,7 @@ import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { Conversation } from '../../components/Conversation'
 import useWalletProvider from '../../hooks/useWalletProvider'
+import { isEns } from '../../helpers/string'
 
 const ConversationPage: NextPage = () => {
   const router = useRouter()
@@ -23,7 +24,7 @@ const ConversationPage: NextPage = () => {
       setRecipientWalletAddr(window.location.pathname.replace('/dm/', ''))
     }
     const checkIfEns = async () => {
-      if (recipientWalletAddr?.includes('.eth')) {
+      if (recipientWalletAddr && isEns(recipientWalletAddr)) {
         const address = await resolveName(recipientWalletAddr)
         router.push(`/dm/${address}`)
       }


### PR DESCRIPTION
## Summary

I wanted to add support for `*.cb.id` addresses via an offchain resolver. We could choose to support more offchain resolvers, but I figured we should just start with 1.

I noticed a bunch of different code paths hardcoding the `.eth` and `0x` checks, so I refactored a bit to use helper functions.

https://user-images.githubusercontent.com/65710/208723935-8cde3f8c-ce6f-4a7a-afb1-dfa93234cd73.mp4

