### PR TITLE
Adding voice memo content type (Work in progress)

### DIFF
--- a/components/Conversation/MessageComposer.tsx
+++ b/components/Conversation/MessageComposer.tsx
@@ -4,27 +4,48 @@ import messageComposerStyles from '../../styles/MessageComposer.module.css'
 import upArrowGreen from '../../public/up-arrow-green.svg'
 import upArrowGrey from '../../public/up-arrow-grey.svg'
 import { useRouter } from 'next/router'
+import { AudioRecorder } from 'react-audio-voice-recorder'
 import Image from 'next/image'
 
 type MessageComposerProps = {
-  onSend: (msg: string) => Promise<void>
+  onSend: (msg: object) => Promise<void>
 }
 
 const MessageComposer = ({ onSend }: MessageComposerProps): JSX.Element => {
-  const [message, setMessage] = useState('')
+  const [message, setMessage] = useState({ content: '', contentType: '' })
   const router = useRouter()
 
-  useEffect(() => setMessage(''), [router.query.recipientWalletAddr])
+  useEffect(
+    () => setMessage({ ...message, content: '' }),
+    [router.query.recipientWalletAddr]
+  )
 
-  const onMessageChange = (e: React.FormEvent<HTMLInputElement>) =>
-    setMessage(e.currentTarget.value)
+  const onMessageChange = (e: React.FormEvent<HTMLInputElement>) => {
+    setMessage({ ...message, content: e.currentTarget.value })
+  }
+
+  const addAudioElement = (blob: Blob) => {
+    const reader = new FileReader()
+    reader.readAsDataURL(blob)
+    return new Promise((_resolve) => {
+      reader.onloadend = () => {
+        setMessage({
+          ...message,
+          content: reader.result,
+          contentType: 'voiceMemo',
+        })
+      }
+    })
+  }
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    if (!message) {
+    const contentMessage = message.content
+
+    if (!contentMessage) {
       return
     }
-    setMessage('')
+    setMessage({ ...message, content: '', contentType: '' })
     await onSend(message)
   }
 
@@ -46,6 +67,7 @@ const MessageComposer = ({ onSend }: MessageComposerProps): JSX.Element => {
         autoComplete="off"
         onSubmit={onSubmit}
       >
+        <AudioRecorder onRecordingComplete={addAudioElement} />
         <input
           type="text"
           placeholder="Type something..."
@@ -58,7 +80,7 @@ const MessageComposer = ({ onSend }: MessageComposerProps): JSX.Element => {
             messageComposerStyles.input
           )}
           name="message"
-          value={message}
+          value={message.content}
           onChange={onMessageChange}
           required
         />

--- a/components/Conversation/MessagesList.tsx
+++ b/components/Conversation/MessagesList.tsx
@@ -15,6 +15,7 @@ export type MessageListProps = {
 
 type MessageTileProps = {
   message: DecodedMessage
+  msg: DecodedMessage
 }
 
 const isOnSameDay = (d1?: Date, d2?: Date): boolean => {
@@ -23,6 +24,23 @@ const isOnSameDay = (d1?: Date, d2?: Date): boolean => {
 
 const formatDate = (d?: Date) =>
   d?.toLocaleString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+
+const TypeOfMessage = ({ msg }: MessageTileProps): JSX.Element => {
+  const contentTypeId = msg.contentType.typeId
+  const isVoiceMemo = contentTypeId === 'voice-key'
+  console.log(contentTypeId)
+
+  debugger
+  if (isVoiceMemo) {
+    return (
+      <audio controls>
+        <source src={msg.content} type="audio/mpeg" />
+      </audio>
+    )
+  } else {
+    return <Emoji text={msg.content || ''} />
+  }
+}
 
 const MessageTile = ({ message }: MessageTileProps): JSX.Element => (
   <div className="flex items-start mx-auto mb-4">
@@ -35,11 +53,12 @@ const MessageTile = ({ message }: MessageTileProps): JSX.Element => (
         </span>
       </div>
       <span className="block text-md px-2 mt-2 text-black font-normal break-words">
-        {message.error ? (
+        <TypeOfMessage msg={message} />
+        {/* {message.error ? (
           `Error: ${message.error?.message}`
         ) : (
           <Emoji text={message.content || ''} />
-        )}
+        )} */}
       </span>
     </div>
   </div>

--- a/hooks/useInitXmtpClient.ts
+++ b/hooks/useInitXmtpClient.ts
@@ -1,4 +1,4 @@
-import { Client } from '@xmtp/xmtp-js'
+import { Client, ContentTypeId } from '@xmtp/xmtp-js'
 import { Signer } from 'ethers'
 import { useCallback, useEffect, useState } from 'react'
 import {
@@ -25,6 +25,33 @@ const useInitXmtpClient = (cacheOnly = false) => {
     }
   }
 
+  const ContentTypeVoiceKey = new ContentTypeId({
+    authorityId: 'xmtp.test',
+    typeId: 'voice-key',
+    versionMajor: 1,
+    versionMinor: 0,
+  })
+
+  class voiceCodec {
+    get contentType() {
+      return ContentTypeVoiceKey
+    }
+
+    encode(key: string | undefined) {
+      return {
+        type: ContentTypeVoiceKey,
+        parameters: {},
+        content: new TextEncoder().encode(key),
+      }
+    }
+
+    decode(content: { content: any }) {
+      const uint8Array = content.content
+      const key = new TextDecoder().decode(uint8Array)
+      return key
+    }
+  }
+
   const initClient = useCallback(
     async (wallet: Signer) => {
       if (wallet && !client) {
@@ -45,6 +72,7 @@ const useInitXmtpClient = (cacheOnly = false) => {
             env: getEnv(),
             appVersion: getAppVersion(),
             privateKeyOverride: keys,
+            codecs: [new voiceCodec()],
           })
           setClient(xmtp)
           setIsRequestPending(false)

--- a/hooks/useSendMessage.ts
+++ b/hooks/useSendMessage.ts
@@ -1,10 +1,27 @@
-import { Conversation } from '@xmtp/xmtp-js'
+import { Conversation, ContentTypeId } from '@xmtp/xmtp-js'
 import { useCallback } from 'react'
 
 const useSendMessage = (selectedConversation?: Conversation) => {
   const sendMessage = useCallback(
-    async (message: string) => {
-      await selectedConversation?.send(message)
+    async (message: object) => {
+      const ContentTypeVoiceKey = new ContentTypeId({
+        authorityId: 'xmtp.test',
+        typeId: 'voice-key',
+        versionMajor: 1,
+        versionMinor: 0,
+      })
+
+      const messageText = message.content
+      const isVoiceMemo = message.contentType === 'voiceMemo'
+
+      if (isVoiceMemo) {
+        await selectedConversation?.send(messageText, {
+          contentType: ContentTypeVoiceKey,
+          contentFallback: 'This is a voice memo',
+        })
+      } else {
+        await selectedConversation?.send(messageText)
+      }
     },
     [selectedConversation]
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "imagemin-svgo": "^9.0.0",
         "next": "13.0.5",
         "react": "18.2.0",
+        "react-audio-voice-recorder": "^1.0.4",
         "react-blockies": "^1.4.1",
         "react-dom": "18.2.0",
         "react-emoji-render": "^1.2.4",
@@ -11692,6 +11693,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-audio-voice-recorder": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-audio-voice-recorder/-/react-audio-voice-recorder-1.0.4.tgz",
+      "integrity": "sha512-NqMQqZZIau8cmzKUsf43s8rWF5lJPPebj+o6tkcX83dv2lLDdJL+jUFspynMSEZq+/T8NJYH2QUqqDAv9XF4Xw==",
+      "peerDependencies": {
+        "react": ">=16.2.0",
+        "react-dom": ">=16.2.0"
+      }
+    },
     "node_modules/react-blockies": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/react-blockies/-/react-blockies-1.4.1.tgz",
@@ -22482,6 +22492,12 @@
       "requires": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "react-audio-voice-recorder": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/react-audio-voice-recorder/-/react-audio-voice-recorder-1.0.4.tgz",
+      "integrity": "sha512-NqMQqZZIau8cmzKUsf43s8rWF5lJPPebj+o6tkcX83dv2lLDdJL+jUFspynMSEZq+/T8NJYH2QUqqDAv9XF4Xw==",
+      "requires": {}
     },
     "react-blockies": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "imagemin-svgo": "^9.0.0",
     "next": "13.0.5",
     "react": "18.2.0",
+    "react-audio-voice-recorder": "^1.0.4",
     "react-blockies": "^1.4.1",
     "react-dom": "18.2.0",
     "react-emoji-render": "^1.2.4",


### PR DESCRIPTION
## Describe your changes
Creating a custom content-type. This content-type are for voice memos. You are able to record and send your audio via xmtp.

DEMO
https://user-images.githubusercontent.com/92274722/214216110-36b9a7be-1fb7-4fe7-ab84-d54a0face9c0.mov


## Why?
Developer's don't know where to start with creating their own custom content-type. They typically go through our docs but shy away from creating their own content-type because docs don't have good tutorials/examples. 

My goal is to create a video tutorial/and or tutorial doc to get them started and have code samples. 

### notes
- Still work in progress. Creating a PR for others to try
- Need to clean and optimize code
- Did video memos because generally smallest size
-


## Things I need to do
- [ ] Refactor code. It's a hot mess
- [ ] Figure out if sending byteArrays/base64 is the optimal way to send voice memos
- [ ] Disable message box when doing a voice memo and dont show the base64 string in the message box


